### PR TITLE
Linux: Add xdg requirements and Flatpak manifest

### DIFF
--- a/as.may.moat.yml
+++ b/as.may.moat.yml
@@ -1,0 +1,32 @@
+id: as.may.moat
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+base: org.godotengine.godot.BaseApp
+base-version: '4.3'
+sdk: org.freedesktop.Sdk
+command: godot-runner
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=pulseaudio
+  - --share=network
+  - --device=all
+
+modules:
+  - name: MuseumOfAllThings
+    buildsystem: simple
+
+    sources:
+      - type: dir
+        path: .
+
+      - type: file
+        url: https://github.com/cassidyjames/museum-of-all-things/releases/download/1.0.0/MuseumOfAllThings.pck
+        sha256: 8003bc2b3c330acb630ba8030fc1f5de6e4f1bbbe0b5f232b1374b3dee1fcfcb
+
+    build-commands:
+      - install -Dm644 MuseumOfAllThings.pck ${FLATPAK_DEST}/bin/godot-runner.pck
+      - install -Dm644 linux/${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 linux/${FLATPAK_ID}.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
+      - install -Dm644 assets/logo/moat_logo_small.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png

--- a/as.may.moat.yml
+++ b/as.may.moat.yml
@@ -22,8 +22,8 @@ modules:
         path: .
 
       - type: file
-        url: https://github.com/cassidyjames/museum-of-all-things/releases/download/1.0.0/MuseumOfAllThings.pck
-        sha256: 8003bc2b3c330acb630ba8030fc1f5de6e4f1bbbe0b5f232b1374b3dee1fcfcb
+        url: https://github.com/m4ym4y/museum-of-all-things/releases/download/v1.0.0/MuseumOfAllThings.pck
+        sha256: a800c512f962106432cd1b7fe0dcc885e0cf89dcaea5979fb2b022228fcd16cc
 
     build-commands:
       - install -Dm644 MuseumOfAllThings.pck ${FLATPAK_DEST}/bin/godot-runner.pck

--- a/linux/as.may.moat.desktop
+++ b/linux/as.may.moat.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Museum of All Things
+Comment=Explore an infinite 3D museum
+Categories=Game;
+Icon=as.may.moat
+Exec=godot-runner
+Type=Application
+Terminal=false
+Keywords=Wikipedia;VR;3D;Godot;simulation;immersive;

--- a/linux/as.may.moat.metainfo.xml
+++ b/linux/as.may.moat.metainfo.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>as.may.moat</id>
+
+  <name>Museum of All Things</name>
+  <summary>Explore an infinite 3D museum</summary>
+
+  <developer id="as.may">
+    <name translatable="no">Maya Claire</name>
+  </developer>
+
+  <description>
+    <p>Visit the Museum of All Things, a nearly-infinite virtual museum generated from Wikipedia!</p>
+    <p>You can find exhibits on millions of topics, from the Architecture of Liverpool to Zoroastrianism. Search for the topic you want to learn about, or just wander from topic to topic as your curiosity dictates!</p>
+    <p>If you have an OpenXR-compatible headset, you can also visit the MoAT in VR! (Currently, the Oculus Quest is not supported)</p>
+    <p>How does it work? The breadth of the museum is made possible by downloading text and images from Wikipedia and Wikimedia Commons. Every exhibit in the museum corresponds to a Wikipedia article. The walls of the exhibit are covered in images and text from the article, and hallways lead out to other exhibits based on the article's links.</p>
+    <p>The museum is greatly inspired by educational videos that I watched as a kid, and the liminal spaces produced by early CGI. I want to recapture the promise that the internet can be a place of endless learning and exploration. I hope you enjoy your time exploring the Museum of All Things!</p>
+  </description>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-realistic">moderate</content_attribute>
+    <content_attribute id="violence-slavery">mild</content_attribute>
+    <content_attribute id="drugs-alcohol">mild</content_attribute>
+    <content_attribute id="drugs-narcotics">mild</content_attribute>
+    <content_attribute id="drugs-tobacco">mild</content_attribute>
+    <content_attribute id="sex-nudity">intense</content_attribute>
+    <content_attribute id="sex-themes">moderate</content_attribute>
+    <content_attribute id="social-info">mild</content_attribute>
+  </content_rating>
+
+
+  <url type="homepage">https://may.as/</url>
+  <url type="bugtracker">https://github.com/m4ym4y/museum-of-all-things/issues</url>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#74c5d8</color>
+    <color type="primary" scheme_preference="dark">#131c5a</color>
+  </branding>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://img.itch.zone/aW1hZ2UvMzMzMzMzMC8xOTkwMjQ0NS5wbmc=/original/hNIQFs.png</image>
+      <caption>Exhibit of demiregular tiling</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://img.itch.zone/aW1nLzE5OTkyNDAxLnBuZw==/original/V%2Fe9oU.png</image>
+      <caption>Exhibit of flowers</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://img.itch.zone/aW1hZ2UvMzMzMzMzMC8xOTkwMjQ0My5wbmc=/original/%2FU1vf5.png</image>
+      <caption>Exhibit of Viceroys Portrait Gallery (series in the Chapultepec Castle)</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://img.itch.zone/aW1hZ2UvMzMzMzMzMC8xOTkwMjQ0Mi5wbmc=/original/mFG6kr.png</image>
+      <caption>Museum exhibit of Settlers of Catan</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://img.itch.zone/aW1hZ2UvMzMzMzMzMC8xOTkwMjQ0Ni5wbmc=/original/L8S8aS.png</image>
+      <caption>Exhibit of various artwork</caption>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+    <release version="v1.0.0" date="2025-02-23">
+      <description>
+        <p>Initial release version</p>
+      </description>
+    </release>
+  </releases>
+
+  <launchable type="desktop-id">as.may.moat.desktop</launchable>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+</component>


### PR DESCRIPTION
Fixes the Flatpak build part of #26. As much as possible, I've followed the [Flathub Quality Guidelines](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines) to make it easier to get featured there in the future; the one missing piece is the icon which will need to be resized a bit according to the guidelines (but that can be done in a follow-up).

## Desktop launcher

Enables adding the icon to a dock/dash/app launcher/app grid/etc.:
  
  ![screenshot of GNOME dash with MOAT icon](https://github.com/user-attachments/assets/32379a1a-3ab6-4524-adef-7c2bbc758f60)

## MetaInfo

Informs presentation of the app listing on Flathub and in native app store clients like GNOME Software. Brand colors are shown on Flathub and GNOME Software banners, while the [OARS data](https://hughsie.github.io/oars/generate.html) is used to estimate an age rating and reveal content warnings.
    
Banners | GNOME Software | OARS ratings
---- | ---- | ----
![screenshot of banners](https://github.com/user-attachments/assets/a5d537a7-6c9a-40cb-8f3e-bd6ac5fa98d5) | ![Screenshot From 2025-02-26 01-16-15](https://github.com/user-attachments/assets/5cf12df2-ebdd-458f-a412-079d809d20bf) ![Screenshot From 2025-02-26 01-16-26](https://github.com/user-attachments/assets/4628cb7c-9d4f-4ba5-8212-9da8b8327021) | ![OARS ratings](https://github.com/user-attachments/assets/b3c4b907-dfd5-4f17-bfd0-9e296acc15a7)

(ignore the broken screenshot images in GNOME Software; that's a known issue when previewing locally)

## Flatpak manifest

Defines how to build and sandbox the game as a Flatpak, including which static permissions to give it (like access to the network and audio devices).

---

See also: https://cassidyjames.com/blog/publish-godot-engine-game-flathub-flatpak/