### PR TITLE
Enable mipmaps/anisotropic filtering for RichTextItem

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -31,6 +31,7 @@ SettingsManager="*res://scenes/util/SettingsManager.gd"
 UISoundManager="*res://scenes/util/UISoundManager.tscn"
 GlobalGridAccess="*res://scenes/util/GlobalGridAccess.gd"
 CacheControl="*res://scenes/util/CacheControl.gd"
+MipmapThread="*res://scenes/util/MipmapThread.gd"
 
 [display]
 

--- a/scenes/items/LobbyInfo.gd
+++ b/scenes/items/LobbyInfo.gd
@@ -4,4 +4,9 @@ extends MeshInstance3D
 @export_multiline var text = "[Replace me]"
 
 func _ready() -> void:
-	$SubViewport/Control/RichTextLabel.text = text
+  $SubViewport/Control/RichTextLabel.text = text
+  if not Engine.is_editor_hint():
+    MipmapThread.get_viewport_texture_with_mipmaps($SubViewport, func(texture):
+      $Sprite3D.texture = texture
+      $SubViewport.queue_free()
+    )

--- a/scenes/items/LobbyInfo.tscn
+++ b/scenes/items/LobbyInfo.tscn
@@ -47,6 +47,7 @@ visibility_range_end_margin = 3.0
 pixel_size = 0.002
 shaded = true
 double_sided = false
+texture_filter = 5
 texture = SubResource("ViewportTexture_ty80d")
 
 [node name="SubViewport" type="SubViewport" parent="."]

--- a/scenes/items/RichTextItem.gd
+++ b/scenes/items/RichTextItem.gd
@@ -11,6 +11,10 @@ func init(text):
   var t = Util.strip_markup(text)
   label.text = t
   call_deferred("_center_vertically", label)
+  MipmapThread.get_viewport_texture_with_mipmaps.call_deferred($SubViewport, func(texture):
+    $Sprite3D.texture = texture
+    $SubViewport.queue_free()
+  )
 
 func _center_vertically(label):
   # Ensure the SubViewport is sized

--- a/scenes/items/RichTextItem.tscn
+++ b/scenes/items/RichTextItem.tscn
@@ -14,6 +14,7 @@ visibility_range_end = 30.0
 visibility_range_end_margin = 3.0
 visibility_range_fade_mode = 1
 pixel_size = 0.004
+texture_filter = 5
 texture = SubResource("ViewportTexture_54vlm")
 
 [node name="SubViewport" type="SubViewport" parent="."]

--- a/scenes/util/MipmapThread.gd
+++ b/scenes/util/MipmapThread.gd
@@ -1,0 +1,61 @@
+extends Node
+
+var thread: Thread
+
+var mutex := Mutex.new()
+var semaphore := Semaphore.new()
+
+var should_exit := false
+var queue: Array[Callable] = []
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+  thread = Thread.new()
+  thread.start(_thread_loop)
+
+func _exit_tree() -> void:
+  mutex.lock()
+  should_exit = true
+  mutex.unlock()
+  semaphore.post()
+
+  thread.wait_to_finish()
+
+func _thread_loop():
+  while true:
+    semaphore.wait()
+    mutex.lock()
+    if should_exit:
+        mutex.unlock()
+        return
+    var task: Callable = queue.pop_front()
+    mutex.unlock()
+    task.call()
+
+func queue_work(c: Callable):
+  mutex.lock()
+  queue.push_back(c)
+  mutex.unlock()
+  semaphore.post()
+
+func get_mipmapped_texture_async(texture: Texture2D, callback: Callable):
+  var width = texture.get_width()
+  var height = texture.get_height()
+  var rid = texture.get_rid()
+  var format = RenderingServer.texture_get_format(rid)
+  var rd_rid = RenderingServer.texture_get_rd_texture(rid)
+  #print("Requesting download of ", rd_rid)
+  RenderingServer.get_rendering_device().texture_get_data_async(rd_rid, 0, func(array) -> void:
+    #print("Download complete: ", array.size())
+    queue_work(func() -> void:
+      var img = Image.create_from_data(width, height, false, format, array)
+      img.generate_mipmaps()
+      var mipmapped_texture := ImageTexture.create_from_image(img)
+      if callback.is_valid():
+        callback.call_deferred(mipmapped_texture)
+    )
+  )
+
+func get_viewport_texture_with_mipmaps(subviewport: SubViewport, callback: Callable):
+  await RenderingServer.frame_post_draw
+  get_mipmapped_texture_async(subviewport.get_texture(), callback)

--- a/scenes/util/MipmapThread.gd.uid
+++ b/scenes/util/MipmapThread.gd.uid
@@ -1,0 +1,1 @@
+uid://d1g7bbxym4d4l


### PR DESCRIPTION
This is the workaround from https://www.github.com/godotengine/godot/issues/23417 for subviewports not generating mipmaps, but the gpu readback will stutter(most likely?) when entering a room until 4.4 provides an async version, and it should probably generate the mipmaps on another thread as well.  But, as is, it shows how those big text items could look with mipmaps.