### PR TITLE
Godot Export: Correct path for uploading release artifacts

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -109,4 +109,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release upload '${{ github.ref_name }}' * --repo '${{ github.repository }}'
+          gh release upload '${{ github.ref_name }}' */* --repo '${{ github.repository }}'


### PR DESCRIPTION
Since the release job is downloading multiple artifacts, each is placed in a subdirectory. This commit corrects the path passed to `gh release upload` to include all files in subdirectories, instead of matching the directories themselves in the current directory.

Fixes #76. Tested and succeeded [on my fork](https://github.com/cassidyjames/museum-of-all-things/actions/runs/13665528379/job/38206065279).