### PR TITLE
Add support for WebXR

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -640,7 +640,14 @@ vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false
 html/export_icon=true
 html/custom_html_shell=""
-html/head_include=""
+html/head_include="<script src=\"https://cdn.jsdelivr.net/npm/webxr-polyfill@latest/build/webxr-polyfill.min.js\"></script>
+<script>
+var polyfill = new WebXRPolyfill();
+</script>
+<script src=\"https://cdn.jsdelivr.net/npm/webxr-layers-polyfill@latest/build/webxr-layers-polyfill.min.js\"></script>
+<script>
+var layersPolyfill = new WebXRLayersPolyfill();
+</script>"
 html/canvas_resize_policy=2
 html/focus_canvas_on_start=true
 html/experimental_virtual_keyboard=false

--- a/scenes/Main.gd
+++ b/scenes/Main.gd
@@ -13,31 +13,21 @@ var _player
 
 @onready var game_started = false
 @onready var menu_nav_queue = []
-@onready var _xr = Util.is_xr()
 
-func _init() -> void:
-  _player = XrRoot.instantiate() if Util.is_xr() else Player.instantiate()
-  add_child(_player)
-
-  if Util.is_xr():
-    _player = _player.get_node("XROrigin3D")
+var webxr_interface
+var webxr_is_starting = false
 
 func _ready():
   if OS.has_feature("movie"):
     $FpsLabel.visible = false
 
-  if _xr:
-    _player.get_node("XRToolsPlayerBody").rotate_player(-starting_rotation)
+  _recreate_player()
+
+  if Util.is_xr():
     _start_game()
   else:
     GraphicsManager.change_post_processing.connect(_change_post_processing)
     GraphicsManager.init()
-    _player.get_node("Pivot/Camera3D").make_current()
-    _player.rotation.y = starting_rotation
-    _player.max_speed = player_speed
-    _player.smooth_movement = smooth_movement
-    _player.dampening = smooth_movement_dampening
-  _player.position = starting_point
 
   GlobalMenuEvents.return_to_lobby.connect(_on_pause_menu_return_to_lobby)
   GlobalMenuEvents.open_terminal_menu.connect(_use_terminal)
@@ -46,11 +36,42 @@ func _ready():
 
   $DirectionalLight3D.visible = Util.is_compatibility_renderer()
 
-  if not _xr:
+  if not Util.is_xr():
     _pause_game()
+
+  if Util.is_web():
+    webxr_interface = XRServer.find_interface("WebXR")
+    if webxr_interface:
+      webxr_interface.session_supported.connect(_webxr_session_supported)
+      webxr_interface.session_started.connect(_webxr_session_started)
+      webxr_interface.session_ended.connect(_webxr_session_ended)
+      webxr_interface.session_failed.connect(_webxr_session_failed)
+
+      webxr_interface.is_session_supported("immersive-vr")
 
 func _play_sting():
   $GameLaunchSting.play()
+
+func _recreate_player() -> void:
+  if _player:
+    if _player is XROrigin3D:
+      _player = _player.get_parent()
+    remove_child(_player)
+    _player.queue_free()
+
+  _player = XrRoot.instantiate() if Util.is_xr() else Player.instantiate()
+  add_child(_player)
+
+  if Util.is_xr():
+    _player = _player.get_node("XROrigin3D")
+    _player.get_node("XRToolsPlayerBody").rotate_player(-starting_rotation)
+  else:
+    _player.get_node("Pivot/Camera3D").make_current()
+    _player.rotation.y = starting_rotation
+    _player.max_speed = player_speed
+    _player.smooth_movement = smooth_movement
+    _player.dampening = smooth_movement_dampening
+  _player.position = starting_point
 
 func _change_post_processing(post_processing: String):
   if post_processing == "crt":
@@ -59,7 +80,7 @@ func _change_post_processing(post_processing: String):
     $CRTPostProcessing.visible = false
 
 func _start_game():
-  if not _xr:
+  if not Util.is_xr():
     if Input.get_mouse_mode() == Input.MOUSE_MODE_VISIBLE:
       Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
     _player.start()
@@ -69,6 +90,20 @@ func _start_game():
   if not game_started:
     game_started = true
     $Museum.init(_player)
+
+func _on_main_menu_start_webxr() -> void:
+  # Prevent clicking the button multiple times.
+  if webxr_is_starting:
+    return
+
+  if webxr_interface:
+    webxr_is_starting = true
+    webxr_interface.session_mode = "immersive-vr"
+    webxr_interface.requested_reference_space_types = "local-floor, local"
+    webxr_interface.optional_features = 'local-floor'
+    if not webxr_interface.initialize():
+      OS.alert("Failed to initialize WebXR")
+      webxr_is_starting = false
 
 func _pause_game():
   _player.pause()
@@ -157,15 +192,44 @@ func _input(event):
   if Input.is_action_just_pressed("show_fps"):
     $FpsLabel.visible = not $FpsLabel.visible
 
-  if event.is_action_pressed("pause") and not _xr:
+  if event.is_action_pressed("pause") and not Util.is_xr():
     _pause_game()
 
-  if event.is_action_pressed("free_pointer") and not _xr:
+  if event.is_action_pressed("free_pointer") and not Util.is_xr():
     Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
-  if event.is_action_pressed("click") and not _xr and not $CanvasLayer.visible:
+  if event.is_action_pressed("click") and not Util.is_xr() and not $CanvasLayer.visible:
     if Input.get_mouse_mode() == Input.MOUSE_MODE_VISIBLE:
       Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
   $FpsLabel.text = str(Engine.get_frames_per_second())
+
+func _webxr_session_supported(session_mode, supported):
+  if session_mode == 'immersive-vr' and supported:
+    %MainMenu.set_webxr_enabled(true)
+
+func _webxr_session_started():
+  webxr_is_starting = false
+
+  _recreate_player()
+
+  # @todo This should ensure that post-processing effects are disabled
+
+  $CanvasLayer.visible = false
+  get_viewport().use_xr = true
+
+  _start_game()
+
+func _webxr_session_ended():
+  webxr_is_starting = false
+  _recreate_player()
+
+  $CanvasLayer.visible = true
+  get_viewport().use_xr = false
+
+  _open_main_menu()
+
+func _webxr_session_failed(message):
+  webxr_is_starting = false
+  OS.alert("Failed to initialize WebXR: " + message)

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -42,6 +42,7 @@ color = Color(0, 0, 0, 0.501961)
 visible = false
 
 [node name="MainMenu" parent="CanvasLayer" instance=ExtResource("4_elltp")]
+unique_name_in_owner = true
 
 [node name="PauseMenu" parent="CanvasLayer" instance=ExtResource("5_boks6")]
 visible = false
@@ -72,6 +73,7 @@ sky_mode = 1
 [connection signal="resume" from="CanvasLayer/Settings" to="." method="_on_settings_back"]
 [connection signal="settings" from="CanvasLayer/MainMenu" to="." method="_on_main_menu_settings"]
 [connection signal="start" from="CanvasLayer/MainMenu" to="." method="_on_main_menu_start_pressed"]
+[connection signal="start_webxr" from="CanvasLayer/MainMenu" to="." method="_on_main_menu_start_webxr"]
 [connection signal="resume" from="CanvasLayer/PauseMenu" to="." method="_on_main_menu_start_pressed"]
 [connection signal="return_to_lobby" from="CanvasLayer/PauseMenu" to="." method="_on_pause_menu_return_to_lobby"]
 [connection signal="settings" from="CanvasLayer/PauseMenu" to="." method="_on_pause_menu_settings"]

--- a/scenes/XRRoot.tscn
+++ b/scenes/XRRoot.tscn
@@ -34,6 +34,7 @@ script = ExtResource("1_t4l57")
 tracker = &"left_hand"
 
 [node name="XRToolsMovementDirect" type="Node" parent="XROrigin3D/XRController3D_left" groups=["movement_providers"]]
+unique_name_in_owner = true
 script = ExtResource("6_mvrkt")
 max_speed = 5.0
 strafe = true
@@ -66,6 +67,7 @@ tracker = &"right_hand"
 hand_material_override = ExtResource("4_jb2jl")
 
 [node name="XRToolsMovementTurn" type="Node" parent="XROrigin3D/XRController3D_right" groups=["movement_providers"]]
+unique_name_in_owner = true
 script = ExtResource("6_80eyh")
 turn_mode = 1
 step_turn_angle = 40.0

--- a/scenes/menu/MainMenu.gd
+++ b/scenes/menu/MainMenu.gd
@@ -1,6 +1,7 @@
 extends Control
 
 signal start
+signal start_webxr
 signal settings
 
 var fade_in_start = Color(0.0, 0.0, 0.0, 1.0)
@@ -18,6 +19,9 @@ func _on_visibility_changed():
   if visible:
     $MarginContainer/VBoxContainer/Start.grab_focus()
 
+func set_webxr_enabled(p_enabled):
+  %StartWebXR.visible = p_enabled
+
 func _start_fade_in():
   $FadeIn.color = fade_in_start
   $FadeInStage2.color = fade_in_start
@@ -29,6 +33,9 @@ func _start_fade_in():
 
 func _on_start_pressed():
   emit_signal("start")
+
+func _on_start_web_xr_pressed() -> void:
+  emit_signal("start_webxr")
 
 func _on_settings_pressed():
   emit_signal("settings")

--- a/scenes/menu/MainMenu.tscn
+++ b/scenes/menu/MainMenu.tscn
@@ -50,6 +50,13 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "Enter the Museum"
 
+[node name="StartWebXR" type="Button" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Enter the Museum in VR (WebXR)"
+
 [node name="Settings" type="Button" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
@@ -88,5 +95,6 @@ color = Color(0, 0, 0, 0)
 
 [connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/Start" to="." method="_on_start_pressed"]
+[connection signal="button_up" from="MarginContainer/VBoxContainer/StartWebXR" to="." method="_on_start_web_xr_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/Settings" to="." method="_on_settings_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/Quit" to="." method="_on_quit_button_pressed"]

--- a/scenes/util/Util.gd
+++ b/scenes/util/Util.gd
@@ -38,8 +38,15 @@ func clear_listeners(n, sig_name):
   for c in list:
     c.signal.disconnect(c.callable)
 
-func is_xr():
+func is_openxr():
   return ProjectSettings.get_setting_with_override("xr/openxr/enabled")
+
+func is_webxr():
+  var webxr_interface: WebXRInterface = XRServer.find_interface("WebXR")
+  return webxr_interface and webxr_interface.is_initialized()
+
+func is_xr():
+  return is_openxr() or is_webxr()
 
 func is_web():
   return OS.get_name() == "Web"


### PR DESCRIPTION
This builds or PR https://github.com/m4ym4y/museum-of-all-things/pull/58 (which builds on PR https://github.com/m4ym4y/museum-of-all-things/pull/88) so marking this as DRAFT until those are reviewed and merged.

**Here's a video of this PR in action:**

[![Watch video](https://drive.google.com/thumbnail?id=1IzevNJah-rP9u6jf2sC-p-8At-J_Lm5U)](https://drive.google.com/file/d/1IzevNJah-rP9u6jf2sC-p-8At-J_Lm5U/view)

This could be a nice alternative way to get more people to visit MOAT in VR before there's a native Quest version available in the store :-)

Some notes:

- The "Enter the Museum in VR (WebXR)" button will only appear if support for WebXR is detected, so folks without a headset won't see it
- There are some hitches at times when exhibits are loading, which is not very comfortable in VR. :-( It may make sense in the end to have both a threaded and non-threaded web export? But I think we can figure that out later, it doesn't affect this PR
- I had to refactor a bunch of stuff related to startup and setting up the player, because with WebXR you start in non-XR mode, and then optionally enter XR mode, and can return to non-XR mode again later. So, the player can get recreated, and we can't cache `Util.is_xr()` because it can change

Here's a pair of builds for folks to try (as of 2025-04-01):

- Threads: https://static.snopekgames.com/cached/builds/moat-20250401-01-threads/
- No threads: https://static.snopekgames.com/cached/builds/moat-20250401-01-nothreads/