### PR TITLE
Update CI to use Godot 4.4.1

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -7,7 +7,7 @@ on:
       - released
 
 env:
-  GODOT_VERSION: 4.4-stable
+  GODOT_VERSION: 4.4.1-stable
   EXPORT_NAME: MuseumOfAllThings
 
 jobs:


### PR DESCRIPTION
Now that Godot 4.4.1 has been released and includes some great bug fixes, this updates the GitHub Actions to use that version