### PR TITLE
Japanese translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ an issue and we can discuss it before you put too much work in.
 - Portuguese
 - French
 - Spanish
+- Japanese
 
 ## Roadmap for Future Updates (Not in any order)
 

--- a/assets/resources/lobby_data_ja.tres
+++ b/assets/resources/lobby_data_ja.tres
@@ -1,0 +1,64 @@
+[gd_resource type="Resource" script_class="LobbyData" load_steps=11 format=3 uid="uid://34yga2226k3j"]
+
+[ext_resource type="Script" uid="uid://bdc8jjijlgjox" path="res://resource_definitions/LobbyData.gd" id="1_3ssej"]
+[ext_resource type="Script" uid="uid://ch3nm32ndlrbh" path="res://resource_definitions/LobbyWing.gd" id="2_y4oc8"]
+
+[sub_resource type="Resource" id="Resource_pgwi2"]
+script = ExtResource("2_y4oc8")
+name = "Technology"
+corner_1 = Vector2(-68, -44)
+corner_2 = Vector2(-32, -8)
+exhibits = PackedStringArray("制御者", "ミノックス", "トランジスタ", "陶磁器", "Godot (ゲームエンジン)", "パスチャライゼーション", "核実験", "接着剤", "ローマ水道", "3次元コンピュータグラフィックス", "飛行機", "単純機械", "印刷機", "避妊", "顕微鏡", "ゲーム機", "トレビュシェット", "畜産", "オルドワン石器")
+
+[sub_resource type="Resource" id="Resource_ooopd"]
+script = ExtResource("2_y4oc8")
+name = "Culture"
+corner_1 = Vector2(32, -44)
+corner_2 = Vector2(68, -8)
+exhibits = PackedStringArray("道化師", "竜", "コンビニエンスストア", "ハイタッチ", "ゴンチャロフ (1973年の映画)", "コーヒー", "スープ", "The Backrooms", "タロット", "K-POP", "囲碁", "ヒンドゥー教", "ダンディ", "ゴーレム", "シーシャンティ", "広告", "大洪水", "修道士")
+
+[sub_resource type="Resource" id="Resource_m2ope"]
+script = ExtResource("2_y4oc8")
+name = "Science"
+corner_1 = Vector2(-44, -92)
+corner_2 = Vector2(-8, -36)
+exhibits = PackedStringArray("菌類", "恐竜", "海洋生態系", "地球", "火星の人面岩", "ネズミ", "エビ", "パンノキ", "可視化", "金", "バオバブ", "ヒト", "振り子", "性的二形", "光", "チーズ", "ヤセイカンラン", "湿地", "スローロリス", "チョウ", "木星", "土壌", "フラクタル", "目")
+
+[sub_resource type="Resource" id="Resource_opuc1"]
+script = ExtResource("2_y4oc8")
+name = "Geography"
+corner_1 = Vector2(8, -92)
+corner_2 = Vector2(44, -36)
+exhibits = PackedStringArray("アメリカ合衆国", "南極大陸", "パタゴニア", "チベット", "ペルセポリス", "ペトラ", "台北101", "おっぱい形の山", "リヴァプール", "重慶市", "ピトケアン諸島", "マリアナ海溝", "シベリア鉄道", "フェアフィールド郡 (オハイオ州)", "チャド湖", "セネガル", "ボラボラ島", "ピレネー国立公園", "キリマンジャロ", "キャンベラ", "アマゾン熱帯雨林", "ヨークシャー", "ウルク (メソポタミア)", "黒石")
+
+[sub_resource type="Resource" id="Resource_qiy1c"]
+script = ExtResource("2_y4oc8")
+name = "Art"
+corner_1 = Vector2(-72, 12)
+corner_2 = Vector2(-36, 48)
+exhibits = PackedStringArray("バロック絵画", "フィリピンの漫画", "聖ステファノス修道院", "パブロ・ピカソ", "ルーヴル美術館", "ジョアン・ミロ", "艾未未", "フリーダ・カーロ", "ケーテ・コルヴィッツ", "フランク・ロイド・ライト", "エドガー・ドガ", "洞窟壁画", "ミケランジェロ・ブオナローティ", "フランシスコ・デ・ゴヤ", "フォーヴィスム", "グラフィティ", "古代ギリシアの彫刻", "マウリッツ・エッシャー", "ジョルジュ・スーラ")
+
+[sub_resource type="Resource" id="Resource_l5mfx"]
+script = ExtResource("2_y4oc8")
+name = "People"
+corner_1 = Vector2(36, 12)
+corner_2 = Vector2(72, 48)
+exhibits = PackedStringArray("ポーランド人の一覧", "アルベルト・アインシュタイン", "フレディ・マーキュリー", "コービー・ブライアント", "チンギス・カン", "グリゴリー・ラスプーチン", "ジョージ・フォックス", "2パック", "平塚らいてう", "ウィリアム・シェイクスピア", "ライナス・ポーリング", "ダニー・デヴィート", "J・R・R・トールキン", "メアリー・シェリー", "アレクサンドリア・オカシオ＝コルテス", "イブン・バットゥータ", "マルティン・ルター", "マーティン・ルーサー・キング・ジュニア")
+
+[sub_resource type="Resource" id="Resource_bycfx"]
+script = ExtResource("2_y4oc8")
+name = "History"
+corner_1 = Vector2(-48, 60)
+corner_2 = Vector2(-12, 96)
+exhibits = PackedStringArray("ドイツの歴史", "チェルノブイリ原子力発電所事故", "タイタニック (客船)", "1960年代のカウンターカルチャー", "アメリカ合衆国における人体実験", "新型コロナウイルス感染症の世界的流行 (2019年-)", "中央情報局", "イスラーム黄金時代", "月面着陸", "サンフランシスコ地震", "ハンニバルのアルプス越え", "地下鉄サリン事件", "写真史", "デイヴ・マシューズ・バンドのツアーバス事件", "血の中傷", "オヨ王国", "海賊", "2019年-2020年香港民主化デモ")
+
+[sub_resource type="Resource" id="Resource_yimja"]
+script = ExtResource("2_y4oc8")
+name = "Media"
+corner_1 = Vector2(12, 60)
+corner_2 = Vector2(48, 96)
+exhibits = PackedStringArray("聖書", "ビートルズ", "マトリックス (映画)", "オデュッセイア", "ギルガメシュ叙事詩", "ゴドーを待ちながら", "Homestuck", "スタートレック", "バービー (映画)", "新世紀エヴァンゲリオン", "ハムレット", "カタンの開拓者たち", "Twitter", "ヴォーグ (雑誌)", "蒸気船ウィリー", "モンテ・クリスト伯", "ウィキペディア", "Minecraft")
+
+[resource]
+script = ExtResource("1_3ssej")
+wings = Array[ExtResource("2_y4oc8")]([SubResource("Resource_pgwi2"), SubResource("Resource_ooopd"), SubResource("Resource_m2ope"), SubResource("Resource_opuc1"), SubResource("Resource_qiy1c"), SubResource("Resource_l5mfx"), SubResource("Resource_bycfx"), SubResource("Resource_yimja")])

--- a/assets/translations/en.po
+++ b/assets/translations/en.po
@@ -22,11 +22,17 @@ msgstr "The museum is currently unstaffed. Please refer to signage for informati
 msgid "English"
 msgstr "English"
 
+msgid "Spanish"
+msgstr "Español"
+
 msgid "Portuguese"
-msgstr "Portuguese"
+msgstr "Português"
 
 msgid "French"
-msgstr "French"
+msgstr "Français"
+
+msgid "Japanese"
+msgstr "日本語"
 
 msgid "Are you sure you want to Quit?"
 msgstr "Are you sure you want to Quit?"
@@ -37,8 +43,17 @@ msgstr "Yes"
 msgid "No"
 msgstr "No"
 
+msgid "Open Page in Browser"
+msgstr "Open Page in Browser"
+
 msgid "Paused"
 msgstr "Paused"
+
+msgid " - Paused"
+msgstr "- Paused"
+
+msgid "Lobby"
+msgstr "Lobby"
 
 msgid "Resume"
 msgstr "Resume"
@@ -97,10 +112,22 @@ msgstr "Preparing Exhibit..."
 msgid "Error Loading Exhibit."
 msgstr "Error Loading Exhibit."
 
+msgid "Graphics"
+msgstr "Graphics"
+
+msgid "Audio"
+msgstr "Audio"
+
+msgid "Data"
+msgstr "Data"
+
+msgid "Controls"
+msgstr "Controls"
+
 msgid "Data Settings"
 msgstr "Data Settings"
 
-msgid "Cache"
+msgid "Cache" ### Currently not applied (probably due to the values that follow)
 msgstr "Cache"
 
 msgid "Clear Cache"
@@ -133,6 +160,15 @@ msgstr "Ambient Light Level"
 msgid "Enable Indirect Lighting (SSIL)"
 msgstr "Enable Indirect Lighting (SSIL)"
 
+msgid "Render Distance"
+msgstr "Render Distance"
+
+msgid "Fog"
+msgstr "Fog"
+
+msgid "Maximum FPS"
+msgstr "Maximum FPS"
+
 msgid "Enable Fog"
 msgstr "Enable Fog"
 
@@ -142,11 +178,50 @@ msgstr "Enable V-Sync"
 msgid "Limit FPS"
 msgstr "Limit FPS"
 
+msgid "Post-Processing Effect"
+msgstr "Post-Processing Effect"
+
 msgid "None"
 msgstr "None"
 
 msgid "CRT Filter"
 msgstr "CRT Filter"
+
+msgid "Control Settings"
+msgstr "Control Settings"
+
+msgid "Mouse Sensitivity"
+msgstr "Mouse Sensitivity"
+
+msgid "Invert Y-axis"
+msgstr "Invert Y-axis"
+
+msgid "Remap Inputs"
+msgstr "Remap Inputs"
+
+msgid "Move Forward"
+msgstr "Move Forward"
+
+msgid "Move Back"
+msgstr "Move Back"
+
+msgid "Strafe Left"
+msgstr "Strafe Left"
+
+msgid "Strafe Right"
+msgstr "Strafe Right"
+
+msgid "Jump"
+msgstr "Jump"
+
+msgid "Crouch"
+msgstr "Crouch"
+
+msgid "Interact"
+msgstr "Interact"
+
+msgid "Joypad Camera Deadzone"
+msgstr "Joypad Camera Deadzone"
 
 msgid "Audio Settings"
 msgstr "Audio Settings"
@@ -159,6 +234,9 @@ msgstr "Sound Effects Volume"
 
 msgid "Ambience Volume"
 msgstr "Ambience Volume"
+
+msgid "Music Volume"
+msgstr "Music Volume"
 
 msgid "Enter VR"
 msgstr "Enter VR"

--- a/assets/translations/ja.po
+++ b/assets/translations/ja.po
@@ -49,8 +49,14 @@ msgstr "ブラウザで開く"
 msgid "Lobby"
 msgstr "ロビー"
 
+msgid "Paused"
+msgstr "（ポーズ中）"
+
 msgid " - Paused"
 msgstr "（ポーズ中）"
+
+msgid "Lobby"
+msgstr "ロビー"
 
 msgid "Resume"
 msgstr "もどる"
@@ -125,8 +131,8 @@ msgstr "操作"
 msgid "Data Settings"
 msgstr "データ設定"
 
-msgid "Cache (- GB)"   
-msgstr "キャッシュ（~ GB）"
+msgid "Cache"   
+msgstr "キャッシュ"
 
 msgid "Clear Cache"
 msgstr "キャッシュをクリア"

--- a/assets/translations/ja.po
+++ b/assets/translations/ja.po
@@ -1,0 +1,416 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Museum of All Things\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8-bit\n"
+"Language: ja\n"
+
+msgid "Enter the Museum"
+msgstr "入る"
+
+msgid "Settings"
+msgstr "設定"
+
+msgid "Quit"
+msgstr "終了"
+
+msgid "The museum is currently unstaffed. Please refer to signage for information."
+msgstr "現在、館内にはスタッフがおりません。案内表示をご参照ください。"
+
+# Language options
+msgid "English"
+msgstr "English"
+
+msgid "Spanish"
+msgstr "Español"
+
+msgid "Portuguese"
+msgstr "Português"
+
+msgid "French"
+msgstr "Français"
+
+msgid "Japanese"
+msgstr "日本語"
+
+msgid "Are you sure you want to Quit?"
+msgstr "本当に終了しますか？"
+
+msgid "Yes"
+msgstr "はい"
+
+msgid "No"
+msgstr "いいえ"
+
+msgid "Open Page in Browser"
+msgstr "ブラウザで開く"
+
+msgid "Paused"  # Doesn't apply due to the coded part (Eg. "Lobby -" before "Paused")
+msgstr "（ポーズ中）"
+
+msgid "Resume"
+msgstr "もどる"
+
+msgid "Return to Lobby"
+msgstr "ロビーに戻る"
+
+msgid "Enter Exhibit Name"
+msgstr "展示を名前で検索する"
+
+msgid "Go to Random Exhibit"
+msgstr "ランダムな展示を見る"
+
+msgid "Enter exhibit title"
+msgstr "展示名を入力"
+
+msgid "Confirm"
+msgstr "決定"
+
+msgid "Back"
+msgstr "戻る"
+
+msgid "Exhibit Found: \"\""
+msgstr "展示が見つかりました：\"\""
+
+msgid "OK / Exit"
+msgstr "閉じる"
+
+# VR Settings
+msgid "VR Controls"
+msgstr "VR操作"
+
+msgid "Restore Default Settings"
+msgstr "デフォルトに戻す"
+
+msgid "Movement Style"
+msgstr "動き方"
+
+msgid "Teleportation (Left Trigger)"
+msgstr "テレポート（左トリガー）"
+
+msgid "Direct Movement (Left Analog Stick)" 
+msgstr "直接移動 (左アナログスティック)"
+
+msgid "Direct Movement Speed" 
+msgstr "移動速度（直接移動）"
+
+msgid "Camera Rotation Increment (Right Stick)"
+msgstr "カメラ回転角度 (右アナログスティック)"
+
+msgid "Smooth Camera Rotation"
+msgstr "スムーズターン"
+
+msgid "Preparing Exhibit..."
+msgstr "準備中"
+
+msgid "Error Loading Exhibit."
+msgstr "展示をご用意できませんでした。"
+
+msgid "Data Settings"
+msgstr "データ設定"
+
+msgid "Cache"   # Currently not applied (probably due to the values that follow)
+msgstr "キャッシュ"
+
+msgid "Clear Cache"
+msgstr "キャッシュをクリア"
+
+msgid "Cache Size Limit"
+msgstr "キャッシュの最大容量"
+
+msgid "Automatically limit cache size (on quit)"
+msgstr "終了時にキャッシュ容量を自動で最適化する"
+
+# Graphics Settings
+msgid "Graphics Settings"
+msgstr "グラフィック設定"
+
+msgid "Render Scale"
+msgstr "レンダースケール"
+
+msgid "Fullscreen"
+msgstr "フルスクリーン"
+
+msgid "Reflection Quality"
+msgstr "反射の精度"
+
+msgid "Enable Reflections"
+msgstr "光の反射を有効化"
+
+msgid "Ambient Light Level"
+msgstr "館内の明るさ"
+
+msgid "Enable Indirect Lighting (SSIL)"
+msgstr "間接照明（SSIL）を有効化"
+
+msgid "Render Distance"
+msgstr "描画距離"
+
+msgid "Fog"
+msgstr "フォグ"
+
+msgid "Maximum FPS"
+msgstr "最大フレームレート"
+
+msgid "Enable Fog"
+msgstr "フォグを有効化"
+
+msgid "Enable V-Sync"
+msgstr "V-Syncを有効化"
+
+msgid "Limit FPS"
+msgstr "FPSを制限する"
+
+msgid "Post-Processing Effect"
+msgstr "ポストプロセス"
+
+msgid "None"
+msgstr "なし"
+
+msgid "CRT Filter"
+msgstr "ブラウン管フィルター"
+
+# Control Settings
+msgid "Control Settings"
+msgstr "操作設定"
+
+msgid "Mouse Sensitivity"
+msgstr "マウス感度"
+
+msgid "Invert Y-axis"
+msgstr "Y軸を反転させる"
+
+msgid "Remap Inputs"
+msgstr "ボタン割り当ての変更"
+
+msgid "Move Forward"
+msgstr "前"
+
+msgid "Move Back"
+msgstr "後ろ"
+
+msgid "Strafe Left"
+msgstr "左"
+
+msgid "Strafe Right"
+msgstr "右"
+
+msgid "Jump"
+msgstr "ジャンプ"
+
+msgid "Crouch"
+msgstr "しゃがみ"
+
+msgid "Interact"
+msgstr "調べる"
+
+msgid "Joypad Camera Deadzone"
+msgstr "カメラ操作のデッドゾーン"
+
+msgid "Audio Settings"
+msgstr "オーディオ設定"
+
+msgid "Global Volume"
+msgstr "マスター"
+
+msgid "Sound Effects Volume"
+msgstr "効果音"
+
+msgid "Ambience Volume"
+msgstr "環境音"
+
+msgid "Music Volume"
+msgstr "音楽"
+
+msgid "Enter VR"
+msgstr "VRモード"
+
+msgid "Snap turning:"
+msgstr "スナップ回転："
+
+msgid "Y axis dead zone"
+msgstr "Y軸デッドゾーン"
+
+msgid "X axis dead zone"
+msgstr "X軸デッドゾーン"
+
+msgid "Haptics Scale"
+msgstr "触覚フィードバック強度"
+
+msgid "Apply"
+msgstr "適用"
+
+msgid "Reset"
+msgstr "リセット"
+
+msgid "Height adjust:"
+msgstr "高さの調整："
+
+msgid "WebXR primary:"
+msgstr "WebXRメインデバイス"
+
+msgid "Auto"
+msgstr "オート"
+
+msgid "Thumbstick"
+msgstr "アナログスティック"
+
+msgid "Trackpad"
+msgstr "トラックパッド"
+
+msgid "Technology"
+msgstr "Technology"
+
+msgid "Featured Technology Exhibits"
+msgstr "「テクノロジー」\nに関する注目の展示"
+
+msgid "Science"
+msgstr "Science"
+
+msgid "Featured Science Exhibits"
+msgstr "「サイエンス」\nに関する注目の展示"
+
+msgid "Geography"
+msgstr "Geography"
+
+msgid "Featured Geography Exhibits"
+msgstr "「地理」\nに関する注目の展示"
+
+msgid "Culture"
+msgstr "Culture"
+
+msgid "Featured Culture Exhibits"
+msgstr "「文化・カルチャー」\nに関する注目の展示"
+
+msgid "Art"
+msgstr "Art"
+
+msgid "Featured Art Exhibits"
+msgstr "「美術・アート」\nに関する注目の展示"
+
+msgid "People"
+msgstr "People"
+
+msgid "Featured People Exhibits"
+msgstr "「人物」\nに関する注目の展示"
+
+msgid "History"
+msgstr "History"
+
+msgid "Featured History Exhibits"
+msgstr "「歴史」\nに関する注目の展示"
+
+msgid "Media"
+msgstr "Media"
+
+msgid "Featured Media Exhibits"
+msgstr "「メディア」\nに関する注目の展示"
+
+msgid "Search"
+msgstr "Search"
+
+msgid "Featured Search Exhibits"
+msgstr "検索"
+
+### scenes/Lobby.tscn Section
+
+msgid ""
+"[b]Welcome to the Museum of All Things![/b]\n"
+"\n"
+"[fill]This museum is different from any you've visited in the physical world, so it may take a moment to get your bearings.[/fill]\n"
+"\n"
+"[b]The Lobby[/b]\n"
+"\n"
+"[fill]Right now you are in the museum's lobby, tailored to give you a pleasant starting point on your visit. If you ever wish to return here, you may simply open your museum menu (via \"Escape,\" \"Start,\" or by hitting \"Y\" on your right-hand controller in Virtual Reality) and select \"Return to Lobby.\"\n"
+"\n"
+"The lobby is divided into areas by subject, which are marked by signs and indicated on the maps in the entry hall behind you. In each of these areas, you will find many hallways into a range of fascinating exhibits.[/fill]"
+msgstr ""
+"[b]MoAT へようこそ。[/b]\n"　
+"\n"
+"[fill]ここは、あらゆるモノや事柄を展示する博物館。[/fill]\n[fill]あなたがこれまで訪れたどの博物館とも異なる空間です。[/fill]\n"
+"\n"
+"[b]ロビーについて[/b]\n"
+"\n"
+"[fill]現在地は、出発地点となる当館のロビーです。 ロビーに戻りたい場合は、キーボードの「Esc」キー、コントローラーの場合は「Start」ボタン、VRの場合は右コントローラーの「Y」ボタンを押してメニューを開き、「ロビーに戻る」を選択してください。\n"
+"\n"
+"このロビーは、展示カテゴリごとにエリアが分かれています。各エリアの入り口には案内があり、それぞれの位置は後ろにある案内マップに表示されています。各エリアからは無数の通路が伸びており、どれも厳選された展示へと繋がっています。[/fill]"
+
+msgid ""
+"[b]Museum Exhibits[/b]\n"
+"\n"
+"[fill]Exhibits are not made by hand-- they are generated procedurally by pulling images and textual data from Wikipedia and Wikimedia commons. This means any topic with a Wikipedia page can also be accessed as an exhibit in this museum!\n"
+"\n"
+"Furthermore, each exhibit contains many hallways connecting it to other exhibits. These hallways are determined based on the links in the current exhibit's Wikipedia article. You can move from exhibit to exhibit endlessly, following your curiosity.\n"
+"\n"
+"If you prefer to go straight to a particular subject, you may access the search terminal, at the end of the entry hall directly behind you. Simply enter your topic of interest into the terminal's interface, and it will create a hallway for you to walk straight there.[/fill]"
+msgstr ""
+"[b]展示について[/b]\n"
+"\n"
+"[fill]当館の展示は、すべてウィキペディアおよびウィキメディア・コモンズから抽出したテキストや画像データを基に自動的に生成されています。つまり、ウィキペディアに記事がある事柄なら、どんなものでも当館の展示としてご覧いただけます。\n"
+"\n"
+"それぞれの展示室には、他の展示へと繋がる通路がいくつも伸びています。これらの通路は、ウィキペディアの記事にある内部リンクを元に生成されています。お好きなように、心ゆくまで通路を辿り、さまざまな展示をご覧いただけます。\n"
+"\n"
+"特定の展示をお探しの場合は、後ろの通路反対側にある検索ターミナルをご利用いただけます。端末の指示に従ってお探しの展示を検索してください。展示が見つかると、そこへ繋がる通路が開きます。[/fill]"
+
+### scenes/menu/TerminalMenu.tscn Section
+
+msgid ""
+"Welcome to the MoAT Custom Exhibit Terminal\n"
+"\n"
+"You may access a specific exhibit by selecting \"Enter Exhibit Name.\" Alternatively, you may ask for a random exhibit.\n"
+"\n"
+"Hit \"E\" on your keyboard to interact with the terminal, or press Y/△ if you are using a controller.\n"
+"\n"
+msgstr ""
+"こちらは、館内検索ターミナルです。\n"
+"\n"
+"「展示を名前で検索する」を選択して、特定の展示を検索できます。また、ランダムな展示にアクセスすることも可能です。\n"
+"\n"
+"キーボードの「E」キー（コントローラーの場合は「Y」または「△」）を押してご利用ください。\n"
+"\n"
+
+msgid "Enter Exhibit Name "
+msgstr "展示を名前で検索する "
+
+msgid "Go to Random Exhibit "
+msgstr "ランダムな展示を見る "
+
+msgid ""
+"Enter the title of the exhibit you would like to acccess. A path will be routed and the door will open to the best matching exhibit.\n"
+"\n"
+msgstr ""
+"検索したい展示の名前をご入力ください。\n展示が見つかると、右側のドアが開き、通路が生成されます。\n"
+"\n"
+
+msgid "Enter exhibit title"
+msgstr "展示名を入力"
+
+msgid "Confirm"
+msgstr "決定"
+
+msgid "Back"
+msgstr "戻る"
+
+msgid "Exhibit Found: \"\"\n"
+msgstr "展示が見つかりました：\"\"\n"
+
+msgid ""
+"\n"
+"Proceed to your right to access this exhibit, or return to the terminal's main menu to access a different exhibit.\n"
+"\n"
+msgstr ""
+"\n"
+"右側の通路にお進みください。別の展示を検索する場合は、\nターミナルのメインメニューに戻り、もう一度検索してください。\n"
+"\n"
+
+msgid "OK / Exit"
+msgstr "閉じる"
+
+msgid ""
+"We were unable to locate the exhibit that you requested. Please try a different exhibit.\n"
+"\n"
+msgstr ""
+"お探しの展示は見つかりませんでした。もう一度お試しください。\n"
+"\n"

--- a/assets/translations/ja.po
+++ b/assets/translations/ja.po
@@ -19,7 +19,6 @@ msgstr "終了"
 msgid "The museum is currently unstaffed. Please refer to signage for information."
 msgstr "現在、館内にはスタッフがおりません。案内表示をご参照ください。"
 
-# Language options
 msgid "English"
 msgstr "English"
 
@@ -47,7 +46,10 @@ msgstr "いいえ"
 msgid "Open Page in Browser"
 msgstr "ブラウザで開く"
 
-msgid "Paused"  # Doesn't apply due to the coded part (Eg. "Lobby -" before "Paused")
+msgid "Lobby"
+msgstr "ロビー"
+
+msgid " - Paused"
 msgstr "（ポーズ中）"
 
 msgid "Resume"
@@ -108,11 +110,23 @@ msgstr "準備中"
 msgid "Error Loading Exhibit."
 msgstr "展示をご用意できませんでした。"
 
+msgid "Graphics"
+msgstr "グラフィックス"
+
+msgid "Audio"
+msgstr "オーディオ"
+
+msgid "Data"
+msgstr "データ"
+
+msgid "Controls"
+msgstr "操作"
+
 msgid "Data Settings"
 msgstr "データ設定"
 
-msgid "Cache"   # Currently not applied (probably due to the values that follow)
-msgstr "キャッシュ"
+msgid "Cache (- GB)"   
+msgstr "キャッシュ（~ GB）"
 
 msgid "Clear Cache"
 msgstr "キャッシュをクリア"

--- a/project.godot
+++ b/project.godot
@@ -42,6 +42,10 @@ window/subwindows/embed_subwindows=false
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 
+[dotnet]
+
+project/assembly_name="Museum of All Things"
+
 [editor]
 
 movie_writer/movie_file="/home/maya/Videos/opening.avi"
@@ -190,10 +194,10 @@ toggle_fullscreen={
 [internationalization]
 
 locale/translation_remaps={
-"res://assets/resources/lobby_data.tres": PackedStringArray("res://assets/resources/lobby_data_pt.tres:pt", "res://assets/resources/lobby_data_fr.tres:fr", "res://assets/resources/lobby_data_es.tres:es"),
+"res://assets/resources/lobby_data.tres": PackedStringArray("res://assets/resources/lobby_data_pt.tres:pt", "res://assets/resources/lobby_data_fr.tres:fr", "res://assets/resources/lobby_data_es.tres:es", "res://assets/resources/lobby_data_ja.tres:ja"),
 "res://assets/textures/lobby_plaque_intro_1.png": PackedStringArray()
 }
-locale/translations=PackedStringArray("res://assets/translations/fr.po", "res://assets/translations/pt.po", "res://assets/translations/en.po", "res://assets/translations/es.po")
+locale/translations=PackedStringArray("res://assets/translations/fr.po", "res://assets/translations/pt.po", "res://assets/translations/en.po", "res://assets/translations/es.po", "res://assets/translations/ja.po")
 locale/test="en"
 locale/locale_filter_mode=0
 locale/language_filter=["en"]


### PR DESCRIPTION
**Added Japanese translation according to [the amazing guide](https://github.com/m4ym4y/museum-of-all-things/blob/main/docs/translation-guide.md) :)**

**◼️ Files modified/added**
- README.md
- project.godot
- assets/translations/ja.po
- assets/resources/lobby_data_ja.tres

**◼️ About untranslated texts**
Some texts remain untranslated (Eg. area names such as "Technology" and "People"). This is intentional, and the texts are kept in English for aesthetic reasons. 

**◼️ Substitutions for exhibits listed in lobby_data.tres**
Some exhibits listed in the original lobby_data.tres are not available on the Japanese wiki. Here's the full list of exhibits that were replaced:

_Technology_
- [Aqueduct (water supply)](https://en.wikipedia.org/wiki/Aqueduct_(water_supply)) → [ローマ水道 (Roman aqueduct)](https://ja.wikipedia.org/wiki/%E3%83%AD%E3%83%BC%E3%83%9E%E6%B0%B4%E9%81%93)
- [3D Rendering](https://en.wikipedia.org/wiki/3D_rendering) → [3次元コンピュータグラフィックス (3DCG)](https://ja.wikipedia.org/wiki/3%E6%AC%A1%E5%85%83%E3%82%B3%E3%83%B3%E3%83%94%E3%83%A5%E3%83%BC%E3%82%BF%E3%82%B0%E3%83%A9%E3%83%95%E3%82%A3%E3%83%83%E3%82%AF%E3%82%B9)
- [Microscopy](https://en.wikipedia.org/wiki/Microscopy) → [顕微鏡 (Microscope)](https://ja.wikipedia.org/wiki/%E9%A1%95%E5%BE%AE%E9%8F%A1)

_Science_

- [Marine Life](https://en.wikipedia.org/wiki/Marine_life) → [海洋生態系 (Marine ecosystem)](https://ja.wikipedia.org/wiki/%E6%B5%B7%E6%B4%8B%E7%94%9F%E6%85%8B%E7%B3%BB)
- [Arabia quadrangle](https://en.wikipedia.org/wiki/Arabia_quadrangle) → [火星の人面岩 (Face on Mars)](https://ja.wikipedia.org/wiki/%E7%81%AB%E6%98%9F%E3%81%AE%E4%BA%BA%E9%9D%A2%E5%B2%A9)

_Geography_

- [Architecture of Liverpool](https://en.wikipedia.org/wiki/Architecture_of_Liverpool) → [リヴァプール (Liverpool)](https://ja.wikipedia.org/wiki/%E3%83%AA%E3%83%B4%E3%82%A1%E3%83%97%E3%83%BC%E3%83%AB)
- [Lancaster, Ohio](https://en.wikipedia.org/wiki/Lancaster,_Ohio) → [フェアフィールド郡 (オハイオ州) (Fairfield County)](https://ja.wikipedia.org/wiki/%E3%83%95%E3%82%A7%E3%82%A2%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E3%83%89%E9%83%A1_(%E3%82%AA%E3%83%8F%E3%82%A4%E3%82%AA%E5%B7%9E))
- [Landes de Gascogne](https://en.wikipedia.org/wiki/Landes_de_Gascogne) → [ピレネー国立公園 (Parc national des Pyrénées)](https://ja.wikipedia.org/wiki/%E3%83%94%E3%83%AC%E3%83%8D%E3%83%BC%E5%9B%BD%E7%AB%8B%E5%85%AC%E5%9C%92)
- [River Wharfe](https://en.wikipedia.org/wiki/River_Wharfe) → [ヨークシャー (Yorkshire)](https://ja.wikipedia.org/wiki/%E3%83%A8%E3%83%BC%E3%82%AF%E3%82%B7%E3%83%A3%E3%83%BC)
 
_Art_

- [Arts in the Philippines](https://en.wikipedia.org/wiki/Arts_in_the_Philippines) → [フィリピンの漫画 (Philippine comics)](https://ja.wikipedia.org/wiki/%E3%83%95%E3%82%A3%E3%83%AA%E3%83%94%E3%83%B3%E3%81%AE%E6%BC%AB%E7%94%BB)
- [Armenian Architecture](https://en.wikipedia.org/wiki/Armenian_architecture) → [聖ステファノス修道院 (Saint Stepanos Monastery)](https://ja.wikipedia.org/wiki/%E8%81%96%E3%82%B9%E3%83%86%E3%83%95%E3%82%A1%E3%83%8E%E3%82%B9%E4%BF%AE%E9%81%93%E9%99%A2)

_People_

- [Luigi Mangione](https://en.wikipedia.org/wiki/Luigi_Mangione) → [平塚らいてう (HIratsuka Raichō)](https://ja.wikipedia.org/wiki/%E5%B9%B3%E5%A1%9A%E3%82%89%E3%81%84%E3%81%A6%E3%81%86)

_History_

- [Drake-Kendrick Lamar feud](https://en.wikipedia.org/wiki/Drake%E2%80%93Kendrick_Lamar_feud) → [地下鉄サリン事件 (Tokyo subway sarin attack)](https://ja.wikipedia.org/wiki/%E5%9C%B0%E4%B8%8B%E9%89%84%E3%82%B5%E3%83%AA%E3%83%B3%E4%BA%8B%E4%BB%B6)


