### PR TITLE
GitHub Actions: Make desktop OpenXR and web builds

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -57,7 +57,7 @@ jobs:
           ./tools/godot --import --headless --verbose
 
       - name: Ensure path exists
-        run: mkdir -p dist
+        run: mkdir -p dist/web
 
       - name: Export PCK
         run: |
@@ -81,6 +81,17 @@ jobs:
           name: Linux
           path: dist/${{ env.EXPORT_NAME }}_Linux.x86_64
 
+      - name: Export Linux (OpenXR)
+        run: |
+          ./tools/godot --verbose --headless --export-release \
+          "Linux (OpenXR)" ./dist/${EXPORT_NAME}_Linux_OpenXR.x86_64
+
+      - name: Upload Linux (OpenXR)
+        uses: actions/upload-artifact@v4
+        with:
+          name: Linux (OpenXR)
+          path: dist/${{ env.EXPORT_NAME }}_Linux_OpenXR.x86_64
+
       - name: Export Windows Desktop
         run: |
           ./tools/godot --verbose --headless --export-release \
@@ -92,6 +103,17 @@ jobs:
           name: Windows Desktop
           path: dist/${{ env.EXPORT_NAME }}.exe
 
+      - name: Export Windows Desktop (OpenXR)
+        run: |
+          ./tools/godot --verbose --headless --export-release \
+          "Windows Desktop (OpenXR)" ./dist/${EXPORT_NAME}_OpenXR.exe
+
+      - name: Upload Windows Desktop (OpenXR)
+        uses: actions/upload-artifact@v4
+        with:
+          name: Windows Desktop (OpenXR)
+          path: dist/${{ env.EXPORT_NAME }}_OpenXR.exe
+
       - name: Export macOS
         run: |
           ./tools/godot --verbose --headless --export-release \
@@ -102,6 +124,19 @@ jobs:
         with:
           name: macOS
           path: dist/${{ env.EXPORT_NAME }}_OSX.zip
+
+      - name: Export Web
+        run: |
+          ./tools/godot --verbose --headless --export-release \
+          "Web" ./dist/web/index.html
+
+          (cd dist/web && zip -r ../${{ env.EXPORT_NAME }}_Web.zip *)
+
+      - name: Upload Web
+        uses: actions/upload-artifact@v4
+        with:
+          name: Web
+          path: dist/${{ env.EXPORT_NAME }}_Web.zip
 
   release:
     name: Attach to Release

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -369,7 +369,7 @@ platform="Android"
 runnable=true
 advanced_options=false
 dedicated_server=false
-custom_features="meta_quest"
+custom_features="meta_quest, openxr"
 export_filter="all_resources"
 include_filter=""
 exclude_filter=""
@@ -653,3 +653,112 @@ progressive_web_app/icon_144x144=""
 progressive_web_app/icon_180x180=""
 progressive_web_app/icon_512x512=""
 progressive_web_app/background_color=Color(0, 0, 0, 1)
+
+[preset.5]
+
+name="Linux (OpenXR)"
+platform="Linux"
+runnable=false
+advanced_options=false
+dedicated_server=false
+custom_features="openxr"
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="dist/MuseumOfAllThings_Linux_OpenXR.x86_64"
+patches=PackedStringArray()
+encryption_include_filters=""
+encryption_exclude_filters=""
+seed=0
+encrypt_pck=false
+encrypt_directory=false
+script_export_mode=2
+
+[preset.5.options]
+
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_wrapper=0
+binary_format/embed_pck=true
+texture_format/s3tc_bptc=true
+texture_format/etc2_astc=false
+binary_format/architecture="x86_64"
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="#!/usr/bin/env bash
+export DISPLAY=:0
+unzip -o -q \"{temp_dir}/{archive_name}\" -d \"{temp_dir}\"
+\"{temp_dir}/{exe_name}\" {cmd_args}"
+ssh_remote_deploy/cleanup_script="#!/usr/bin/env bash
+kill $(pgrep -x -f \"{temp_dir}/{exe_name} {cmd_args}\")
+rm -rf \"{temp_dir}\""
+
+[preset.6]
+
+name="Windows Desktop (OpenXR)"
+platform="Windows Desktop"
+runnable=false
+advanced_options=false
+dedicated_server=false
+custom_features="openxr"
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="dist/MuseumOfAllThings_OpenXR.exe"
+patches=PackedStringArray()
+encryption_include_filters=""
+encryption_exclude_filters=""
+seed=0
+encrypt_pck=false
+encrypt_directory=false
+script_export_mode=2
+
+[preset.6.options]
+
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_wrapper=1
+binary_format/embed_pck=true
+texture_format/s3tc_bptc=true
+texture_format/etc2_astc=false
+binary_format/architecture="x86_64"
+codesign/enable=false
+codesign/timestamp=true
+codesign/timestamp_server_url=""
+codesign/digest_algorithm=1
+codesign/description=""
+codesign/custom_options=PackedStringArray()
+application/modify_resources=true
+application/icon=""
+application/console_wrapper_icon=""
+application/icon_interpolation=4
+application/file_version=""
+application/product_version=""
+application/company_name=""
+application/product_name=""
+application/file_description=""
+application/copyright=""
+application/trademarks=""
+application/export_angle=0
+application/export_d3d12=0
+application/d3d12_agility_sdk_multiarch=true
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="Expand-Archive -LiteralPath '{temp_dir}\\{archive_name}' -DestinationPath '{temp_dir}'
+$action = New-ScheduledTaskAction -Execute '{temp_dir}\\{exe_name}' -Argument '{cmd_args}'
+$trigger = New-ScheduledTaskTrigger -Once -At 00:00
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings
+Register-ScheduledTask godot_remote_debug -InputObject $task -Force:$true
+Start-ScheduledTask -TaskName godot_remote_debug
+while (Get-ScheduledTask -TaskName godot_remote_debug | ? State -eq running) { Start-Sleep -Milliseconds 100 }
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue"
+ssh_remote_deploy/cleanup_script="Stop-ScheduledTask -TaskName godot_remote_debug -ErrorAction:SilentlyContinue
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue
+Remove-Item -Recurse -Force '{temp_dir}'"

--- a/project.godot
+++ b/project.godot
@@ -241,4 +241,4 @@ openxr/reference_space=2
 shaders/enabled=true
 openxr/foveation_level.meta_quest=3
 openxr/foveation_dynamic.meta_quest=true
-openxr/enabled.meta_quest=true
+openxr/enabled.openxr=true


### PR DESCRIPTION
This setups GitHub Actions to make the desktop OpenXR builds and the web build

(The Meta Quest build requires some stuff with an Android keystore, so I'm going to make a separate PR for that)

Fixes https://github.com/m4ym4y/museum-of-all-things/issues/39