### PR TITLE
GitHub Actions: Make the Meta Quest build

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -52,6 +52,17 @@ jobs:
           # Tell Godot Engine to be self-contained
           touch ._sc_
 
+      - name: Set up OpenJDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+        if: github.event_name != 'pull_request'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+        if: github.event_name != 'pull_request'
+
       - name: Import project
         run: |
           ./tools/godot --import --headless --verbose
@@ -137,6 +148,25 @@ jobs:
         with:
           name: Web
           path: dist/${{ env.EXPORT_NAME }}_Web.zip
+
+      - name: Export Meta Quest
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE }}" | base64 -d > android-release.keystore
+
+          export GODOT_ANDROID_KEYSTORE_RELEASE_PATH=android-release.keystore
+          export GODOT_ANDROID_KEYSTORE_RELEASE_USER="${{ secrets.ANDROID_KEYSTORE_USER }}"
+          export GODOT_ANDROID_KEYSTORE_RELEASE_PASSWORD="${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
+
+          ./tools/godot --verbose --headless --install-android-build-template --export-release \
+          "Meta Quest" ./dist/${{ env.EXPORT_NAME }}_Quest.apk
+        if: github.event_name != 'pull_request'
+
+      - name: Upload Meta Quest
+        uses: actions/upload-artifact@v4
+        with:
+          name: Meta Quest
+          path: dist/${{ env.EXPORT_NAME }}_Quest.apk
+        if: github.event_name != 'pull_request'
 
   release:
     name: Attach to Release


### PR DESCRIPTION
This does the Meta Quest build on GitHub Actions, creating the APK!

It depends on adding these secrets to GitHub Actions:

- `ANDROID_KEYSTORE`: The keystore file base64 encoded
- `ANDROID_KEYSTORE_USER`: The keystore user in plain text
- `ANDROID_KEYSTORE_PASSWORD`: The keystore password in plain text

**This will fail CI until the secrets are added to this repo,** but I've tested it on my fork and it's working there

This is the command that I usually use for making an Android keystore, but there's other ways to do it:

```
keytool -genkeypair -v -keystore my-release-key.keystore -alias my-user-name -keyalg RSA -keysize 4096 -validity 10000
```