### PR TITLE
Add FSR scaling modes option

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -230,7 +230,6 @@ common/enable_pause_aware_picking=true
 occlusion_culling/bvh_build_quality=0
 renderer/rendering_method.mobile="gl_compatibility"
 textures/vram_compression/import_etc2_astc=true
-anti_aliasing/quality/msaa_3d=1
 limits/opengl/max_renderable_lights=16
 occlusion_culling/use_occlusion_culling=true
 environment/defaults/default_environment="res://assets/resources/default_env.tres"

--- a/scenes/menu/GraphicsSettings.tscn
+++ b/scenes/menu/GraphicsSettings.tscn
@@ -42,6 +42,56 @@ text = "
 
 [node name="Label" type="Label" parent="DisplayOptions"]
 layout_mode = 2
+text = "Scaling mode"
+
+[node name="ScaleMode" type="OptionButton" parent="DisplayOptions"]
+layout_mode = 2
+selected = 0
+item_count = 3
+popup/item_0/text = "Bilinear"
+popup/item_0/id = 0
+popup/item_1/text = "AMD FSR 1"
+popup/item_1/id = 1
+popup/item_2/text = "AMD FSR 2"
+popup/item_2/id = 2
+
+[node name="Label2" type="Label" parent="DisplayOptions" groups=["fsr_options"]]
+layout_mode = 2
+text = "FSR quality mode"
+
+[node name="FSRQuality" type="OptionButton" parent="DisplayOptions" groups=["fsr_options"]]
+layout_mode = 2
+selected = 0
+item_count = 5
+popup/item_0/text = "Ultra quality"
+popup/item_0/id = 0
+popup/item_1/text = "Quality"
+popup/item_1/id = 1
+popup/item_2/text = "Balanced"
+popup/item_2/id = 2
+popup/item_3/text = "Performance"
+popup/item_3/id = 3
+popup/item_4/text = "Ultra performance"
+popup/item_4/id = 4
+
+[node name="Label3" type="Label" parent="DisplayOptions" groups=["fsr_options"]]
+layout_mode = 2
+text = "FSR Sharpness"
+
+[node name="SharpnessScale" type="HSlider" parent="DisplayOptions" groups=["fsr_options"]]
+layout_mode = 2
+max_value = 2.0
+step = 0.05
+value = 0.2
+
+[node name="SharpnessScaleValue" type="Label" parent="DisplayOptions" groups=["fsr_options"]]
+layout_mode = 2
+text = "0.2
+"
+horizontal_alignment = 1
+
+[node name="Label4" type="Label" parent="DisplayOptions"]
+layout_mode = 2
 text = "Render Scale"
 
 [node name="RenderScale" type="HSlider" parent="DisplayOptions"]
@@ -53,7 +103,7 @@ value = 1.0
 
 [node name="RenderScaleValue" type="Label" parent="DisplayOptions"]
 layout_mode = 2
-text = "1.0
+text = "100 %
 "
 horizontal_alignment = 1
 
@@ -215,6 +265,9 @@ popup/item_1/id = 1
 [connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
 [connection signal="pressed" from="MainOptions/Back" to="." method="_on_resume_pressed"]
 [connection signal="pressed" from="MainOptions/Restore" to="." method="_on_restore_pressed"]
+[connection signal="item_selected" from="DisplayOptions/ScaleMode" to="." method="_on_scale_mode_value_changed"]
+[connection signal="item_selected" from="DisplayOptions/FSRQuality" to="." method="_on_fsr_quality_item_selected"]
+[connection signal="value_changed" from="DisplayOptions/SharpnessScale" to="." method="_on_sharpness_scale_value_changed"]
 [connection signal="value_changed" from="DisplayOptions/RenderScale" to="." method="_on_render_scale_value_changed"]
 [connection signal="toggled" from="DisplayOptions/Fullscreen" to="." method="_on_fullscreen_toggled"]
 [connection signal="value_changed" from="ReflectionOptions/ReflectionQuality" to="." method="_on_reflection_quality_value_changed"]

--- a/scenes/util/GraphicsManager.gd
+++ b/scenes/util/GraphicsManager.gd
@@ -14,6 +14,9 @@ var fps_limit = 60
 var _default_settings_obj
 var fullscreen = false
 var render_scale = 1.0
+var scale_mode = 0
+var fsr_quality = 5
+var fsr_sharpness = 0.2
 var post_processing = "none"
 var render_distance_multiplier = 2.5
 var vsync_enabled = true
@@ -46,6 +49,33 @@ func set_fullscreen(_fullscreen: bool):
 func set_render_scale(scale: float):
   render_scale = scale
   get_viewport().scaling_3d_scale = scale
+
+func set_scale_mode(mode: int):
+  scale_mode = mode
+  get_viewport().scaling_3d_mode = mode as Viewport.Scaling3DMode
+
+  if mode < 2:
+    get_viewport().msaa_3d = Viewport.MSAA_2X
+  else:
+    get_viewport().msaa_3d = Viewport.MSAA_DISABLED
+
+func set_fsr_quality(quality: int):
+  fsr_quality = quality
+
+  match quality:
+    0:
+      get_viewport().scaling_3d_scale = 1.0 / 1.3
+    1:
+      get_viewport().scaling_3d_scale = 1.0 / 1.5
+    2:
+      get_viewport().scaling_3d_scale = 1.0 / 1.7
+    3:
+      get_viewport().scaling_3d_scale = 1.0 / 2.0
+    4:
+      get_viewport().scaling_3d_scale = 1.0 / 3.0
+
+func set_fsr_sharpness(sharpness: float):
+    get_viewport().fsr_sharpness = sharpness
 
 func set_post_processing(_post_processing: String):
   post_processing = _post_processing
@@ -89,8 +119,16 @@ func _apply_settings(s, default={}):
     set_fps_limit(s["fps_limit"] if s.has("fps_limit") else default["fps_limit"])
     enable_fps_limit(s["limit_fps"] if s.has("limit_fps") else default["limit_fps"])
     set_fullscreen(s["fullscreen"] if s.has("fullscreen") else default["fullscreen"])
-    set_render_scale(s["render_scale"] if s.has("render_scale") else default["render_scale"])
+    set_fsr_sharpness(s["fsr_sharpness"] if s.has("fsr_sharpness") else default["fsr_sharpness"])
     set_post_processing(s["post_processing"] if s.has("post_processing") else default["post_processing"])
+
+    var mode = s["scale_mode"] if s.has("scale_mode") else default["scale_mode"]
+    set_scale_mode(mode)
+    if mode > 0:
+        set_fsr_quality(s["fsr_quality"] if s.has("fsr_quality") else default["fsr_quality"])
+    else:
+        set_render_scale(s["render_scale"] if s.has("render_scale") else default["render_scale"])
+
   set_render_distance_multiplier(s["render_distance_multiplier"] if s.has("render_distance_multiplier") else default["render_distance_multiplier"])
 
 func _create_settings_obj():
@@ -105,6 +143,9 @@ func _create_settings_obj():
     "limit_fps": limit_fps,
     "fullscreen": fullscreen,
     "render_scale": render_scale,
+    "scale_mode": scale_mode,
+    "fsr_quality": fsr_quality,
+    "fsr_sharpness": fsr_sharpness,
     "post_processing": post_processing,
     "vsync_enabled": vsync_enabled,
     "render_distance_multiplier": render_distance_multiplier,


### PR DESCRIPTION
Simply add a couple of settings in the menu to choose from different scaling modes:

- Bilinear
- FSR 1.0
- FSR 2.0

I've disabled MSAA when using FSR 2.2, as it contains a TAA as part of its function.