### PR TITLE
Enable Physics Interpolation

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -223,6 +223,7 @@ tls/certificate_bundle_override="res://assets/certs/cacert.crt"
 
 [physics]
 
+common/physics_interpolation=true
 common/enable_pause_aware_picking=true
 
 [rendering]


### PR DESCRIPTION
Just a quick settings change to allow interp physics. Makes the player movement feel smoother at higher framerates and/or framerates higher than the physics tick rate.