### PR TITLE
Automatically run GitHub Actions on branch pushes

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -1,6 +1,9 @@
 name: "Godot"
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - '**'
   pull_request:
   release:
     types:


### PR DESCRIPTION
This way folks will be able to download the artifacts from GitHub Actions builds on `main` and get "preview builds".

I tested on my fork and it seems to work fine!