### PR TITLE
Utility function to fix unclosed BBCode tags

### DIFF
--- a/scenes/items/RichTextItem.gd
+++ b/scenes/items/RichTextItem.gd
@@ -9,6 +9,7 @@ func _process(delta: float) -> void:
 func init(text):
   var label = $SubViewport/Control/RichTextLabel
   var t = Util.strip_markup(text)
+  t = Util.replace_unclosed_bbcodes(t)
   label.text = t
   call_deferred("_center_vertically", label)
   MipmapThread.get_viewport_texture_with_mipmaps.call_deferred($SubViewport, func(texture):

--- a/scenes/util/Util.gd
+++ b/scenes/util/Util.gd
@@ -176,6 +176,29 @@ func trim_to_length_sentence(s, lim):
       break
   return s.substr(0, pos + 1)
 
+func replace_unclosed_bbcodes(text):
+    var bbcode_re = RegEx.new()
+    #Replacing the unclosed: [s] tags with => ()
+    bbcode_re.compile("\\[(\\/)?([s])\\]")
+    var tag_stack = []
+    var result = text
+    var offset = 0
+    for match in bbcode_re.search_all(text):
+        var is_closing = match.get_string(1) == "/"
+        var tag_name = match.get_string(2)
+        var start_pos = match.get_start() + offset
+        var end_pos = match.get_end() + offset
+        if is_closing:
+            if tag_stack and tag_stack[-1] == tag_name:
+                tag_stack.pop_back()
+            result = result.substr(0, start_pos) + result.substr(end_pos)
+            offset -= (end_pos - start_pos)
+        else:
+            tag_stack.push_back(tag_name)
+            result = result.substr(0, start_pos) + "(" + tag_name + ")" + result.substr(end_pos)
+            offset += len("(" + tag_name + ")") - (end_pos - start_pos)
+    return result
+
 var html_tag_re = RegEx.new()
 var display_none_re = RegEx.new()
 var markup_tag_re = RegEx.new()

--- a/scenes/util/Util.gd
+++ b/scenes/util/Util.gd
@@ -177,9 +177,6 @@ func trim_to_length_sentence(s, lim):
   return s.substr(0, pos + 1)
 
 func replace_unclosed_bbcodes(text):
-    var bbcode_re = RegEx.new()
-    #Replacing the unclosed: [s] tags with => ()
-    bbcode_re.compile("\\[(\\/)?([s])\\]")
     var tag_stack = []
     var result = text
     var offset = 0
@@ -199,12 +196,14 @@ func replace_unclosed_bbcodes(text):
             offset += len("(" + tag_name + ")") - (end_pos - start_pos)
     return result
 
+var bbcode_re = RegEx.new()
 var html_tag_re = RegEx.new()
 var display_none_re = RegEx.new()
 var markup_tag_re = RegEx.new()
 var curly_tag_re = RegEx.new()
 func _ready():
   display_none_re.compile("<.*?display:\\s*none.*?>.+?<.*?>")
+  bbcode_re.compile("\\[(\\/)?([s])\\]")
   html_tag_re.compile("<.+?>")
   markup_tag_re.compile("\\.\\w.+? ")
   curly_tag_re.compile("\\{.+?\\}")


### PR DESCRIPTION
This function replaces any unclosed BBCode starting with `[s]`. So far, no other unclosed tags have caused issues (at least I can found), but if they do, the function can be easily updated to handle more BBCode tags.

Closes: https://github.com/m4ym4y/museum-of-all-things/issues/119

**Before:**

![image](https://github.com/user-attachments/assets/729c30a6-d6ab-4c01-9da1-c677e0d1af00)

**After:**

![image](https://github.com/user-attachments/assets/a62832f0-b60e-4f03-afd5-5668a07abf23)

