### PR TITLE
Attempt to fix missing first word in author field

### DIFF
--- a/scenes/items/ImageItem.gd
+++ b/scenes/items/ImageItem.gd
@@ -50,7 +50,7 @@ func _on_image_loaded(url, image, _ctx):
     material_override.set_shader_parameter("texture_albedo", _image)
 
   var label = $Label
-  label.text = Util.strip_markup(text)
+  label.text = text
   call_deferred("_update_text_plate")
 
   var w = _image.get_width()
@@ -105,7 +105,7 @@ func _ready():
     $Label/Plate.material_override = plate_black
 
 func init(_title, _text, _plate_style = null):
-  text = _text
+  text = Util.strip_markup(_text)
   title = _title
   plate_style = _plate_style
 


### PR DESCRIPTION
Fixes https://github.com/m4ym4y/museum-of-all-things/issues/136

I think the problem here is the `Util.strip_markup()` is meant to strip the initial text, but when `_on_image_loaded()` runs, it's after the author text has already been appended (which itself is stripped via `Util.strip_html()`)

So, this PR does the `Util.strip_markup()` on the initial text in `init()`, and then doesn't do any more stripping `_on_image_loaded()`.

However, I may not be right about my assumptions :-)