### PR TITLE
Limit the number of items per exhibit on web and mobile platforms

### DIFF
--- a/scenes/TiledExhibitGenerator.gd
+++ b/scenes/TiledExhibitGenerator.gd
@@ -218,6 +218,8 @@ func add_room():
   if len(_next_room_candidates) == 0:
     push_error("no room candidate to create")
     return
+  if _item_slots.size() > Util.get_max_slots_per_exhibit():
+    return
 
   var idx = _rng.randi() % len(_next_room_candidates)
   var room = _next_room_candidates.pop_at(idx)

--- a/scenes/util/ExhibitFetcher.gd
+++ b/scenes/util/ExhibitFetcher.gd
@@ -10,7 +10,6 @@ signal commons_images_complete(category, context)
 
 const MAX_BATCH_SIZE = 50
 const REQUEST_DELAY_MS = 1000
-const COMMONS_IMAGE_LIMIT = 2500
 
 # TODO: wikimedia support, and category support
 const WIKIMEDIA_COMMONS_PREFIX = "https://commons.wikimedia.org/wiki/"
@@ -469,7 +468,7 @@ func _on_commons_images_request_complete(res, ctx, caller_ctx):
     call_deferred("emit_signal", "commons_images_complete", file_batch, caller_ctx)
 
   # handle continues
-  if res.has("continue") and len(get_result(ctx.category).images) <= COMMONS_IMAGE_LIMIT:
+  if res.has("continue") and len(get_result(ctx.category).images) <= Util.get_max_slots_per_exhibit():
     return _dispatch_continue(res.continue, _get_commons_url(ctx.category), ctx.category, ctx, caller_ctx)
   else:
     _cache_all([ctx.category], WIKIMEDIA_COMMONS_PREFIX)

--- a/scenes/util/Util.gd
+++ b/scenes/util/Util.gd
@@ -51,6 +51,9 @@ func is_xr():
 func is_web():
   return OS.get_name() == "Web"
 
+func is_mobile():
+  return OS.has_feature("mobile")
+
 func is_using_threads():
   return OS.has_feature("threads")
 
@@ -59,6 +62,10 @@ func is_compatibility_renderer():
 
 func is_meta_quest():
   return OS.has_feature("meta_quest")
+
+func get_max_slots_per_exhibit() -> int:
+  # @todo Should this be a setting?
+  return 200 if (is_mobile() or is_web()) else 2500
 
 func delay_msec(msecs):
   # Will only delay if we're not on the main thread.


### PR DESCRIPTION
On the Meta Quest 3, on very large exhibits with enough items, it would tank the frame rate into single digits and even crash the app

(I tested mostly with the "Screenshot" article, and it could pretty reliably crash it, if you waited long enough for all 2500+ items to load)

This limits the number of slots per exhibit to approximately ~200 on web and mobile (it can go a little over - it stops adding rooms to an exhibit once it goes over, but it'll add however many slots for the last room). On all other platforms, it limits to ~2500, which is about where the limit was anyway, because that's the maximum number of images that would be pulled from Wikimedia Commons.

This does mean that exhibits will be different between web/mobile and all other platforms. But, without having texture streaming and occlusion culling (which would be quite a lot of work to implement), I don't think we can have exhibits that big on web/mobile

After this change, I haven't been able to get MOAT to crash at all on any articles on the Meta Quest 3!