### PR TITLE
Add joypad sensitivity slider

### DIFF
--- a/scenes/Player.gd
+++ b/scenes/Player.gd
@@ -26,11 +26,13 @@ var _joy_right_y = JOY_AXIS_RIGHT_Y
 
 var _invert_y = false
 var _mouse_sensitivity_factor = 1.0
+var _joy_sensitivity_factor = 1.0
 
 func _ready():
   GlobalMenuEvents.set_invert_y.connect(_set_invert_y)
   GlobalMenuEvents.set_mouse_sensitivity.connect(_set_mouse_sensitivity)
   GlobalMenuEvents.set_joypad_deadzone.connect(_set_joy_deadzone)
+  GlobalMenuEvents.set_joypad_sensitivity.connect(_set_joy_sensitivity)
 
   starting_height = $Pivot.get_position().y
   crouching_height = starting_height / 3
@@ -44,6 +46,9 @@ func _set_mouse_sensitivity(factor):
 
 func _set_joy_deadzone(value):
   joy_deadzone = value
+  
+func _set_joy_sensitivity(factor):
+  _joy_sensitivity_factor = factor
 
 func pause():
   _enabled = false
@@ -111,8 +116,8 @@ func _physics_process(delta):
   #var delta_vec = Input.get_vector("camera_left", "camera_right", "camera_up", "camera_down")
   var delta_vec = Vector2(-Input.get_joy_axis(0, _joy_right_x), -Input.get_joy_axis(0, _joy_right_y))
   if delta_vec.length() > joy_deadzone:
-    rotate_y(delta_vec.x * joy_sensitivity)
-    $Pivot.rotate_x(delta_vec.y * joy_sensitivity)
+    rotate_y(delta_vec.x * joy_sensitivity * _joy_sensitivity_factor)
+    $Pivot.rotate_x(delta_vec.y * joy_sensitivity * _joy_sensitivity_factor)
     $Pivot.rotation.x = clamp($Pivot.rotation.x, -1.2, 1.2)
 
   if smooth_movement:

--- a/scenes/menu/ControlSettings.gd
+++ b/scenes/menu/ControlSettings.gd
@@ -162,3 +162,7 @@ func _on_sensitivity_value_changed(value: float):
 func _on_deadzone_value_changed(value: float):
   $JoyOptions/DeadzoneValue.text = str(int(value * 100)) + "%"
   GlobalMenuEvents.emit_set_joypad_deadzone(value)
+
+func _on_joypad_sensitivity_value_changed(value: float) -> void:
+  $JoyOptions/SensitivityValue.text = str(int(value * 100)) + "%"
+  GlobalMenuEvents.emit_set_joypad_sensitivity(value)

--- a/scenes/menu/ControlSettings.tscn
+++ b/scenes/menu/ControlSettings.tscn
@@ -89,9 +89,26 @@ layout_mode = 2
 text = "5%"
 horizontal_alignment = 1
 
+[node name="Sensitivity Label" type="Label" parent="JoyOptions"]
+layout_mode = 2
+text = "Joypad Sensitivity"
+
+[node name="Sensitivity" type="HSlider" parent="JoyOptions"]
+layout_mode = 2
+min_value = 0.1
+max_value = 3.0
+step = 0.05
+value = 1.0
+
+[node name="SensitivityValue" type="Label" parent="JoyOptions"]
+layout_mode = 2
+text = "100%"
+horizontal_alignment = 1
+
 [connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
 [connection signal="pressed" from="MainOptions/Back" to="." method="_on_resume"]
 [connection signal="pressed" from="MainOptions/RestoreDefaultsButton" to="." method="_on_restore_defaults_button_pressed"]
 [connection signal="value_changed" from="MouseOptions/Sensitivity" to="." method="_on_sensitivity_value_changed"]
 [connection signal="toggled" from="MouseOptions/InvertY" to="." method="_on_invert_y_toggled"]
 [connection signal="value_changed" from="JoyOptions/Deadzone" to="." method="_on_deadzone_value_changed"]
+[connection signal="value_changed" from="JoyOptions/Sensitivity" to="." method="_on_joypad_sensitivity_value_changed"]

--- a/scenes/util/GlobalMenuEvents.gd
+++ b/scenes/util/GlobalMenuEvents.gd
@@ -18,6 +18,7 @@ signal reset_custom_door
 signal set_invert_y(enabled: bool)
 signal set_mouse_sensitivity(factor: float)
 signal set_joypad_deadzone(value: float)
+signal set_joypad_sensitivity(factor: float)
 signal set_language(language: String)
 
 func emit_ui_cancel_pressed():
@@ -73,6 +74,9 @@ func emit_set_mouse_sensitivity(factor: float):
 
 func emit_set_joypad_deadzone(value: float):
   emit_signal("set_joypad_deadzone", value)
+  
+func emit_set_joypad_sensitivity(factor: float):
+  emit_signal("set_joypad_sensitivity", factor)
 
 func emit_set_language(language: String):
   emit_signal("set_language", language)


### PR DESCRIPTION
This PR adds a Joypad sensitivity slider to the controls settings menu. I used the same values as the mouse sensitivity slider and that seemed to give sensible min and max sensitivity. 

There is an issue with the bottom-most slider in the menu (currently the deadzone slider) in general if it begins below the viewport when navigating with a controller. When you navigate down, the menu scrolls, but it only brings the slider itself into view, not the percentage label below it, so you can't really see what the value is while you're moving the slider. I have [another PR](https://github.com/hallx833/museum-of-all-things/pull/2) in my fork with a proposed solution for this. It adds a percentage slider component that automatically updates its percentage label and keeps it in view by calling ensure_control_visible on the label when the slider is focused. You could probably also just add some margin to the scrolling. Or even just rearrange the menu so the sliders aren't at the bottom.