### PR TITLE
Gracefully handle rate limiting from Wikipedia

### DIFF
--- a/scenes/util/DataManager.gd
+++ b/scenes/util/DataManager.gd
@@ -59,8 +59,21 @@ func _texture_load_item():
           request_url += ('&' if '?' in request_url else '?') + "origin=*"
 
           var handle_result = func(result):
-            if result[0] != OK:
-              push_error("failed to fetch image ", result[1], " ", item.url)
+            if result[0] == OK and result[1] == 429:
+              # Requeue images if we have been rate limited.
+              # See: https://www.mediawiki.org/wiki/Wikimedia_APIs/Rate_limits
+              var delay = 1000
+              for header in result[2]:
+                if header.to_lower().begins_with("retry-after:"):
+                  var delay_seconds = int(header.get_slice(":", 1).strip_edges())
+                  if delay_seconds > 0:
+                    delay = delay_seconds * 1000
+                  break
+              push_warning("rate limited, requeuing image in %dms: %s" % [delay, item.url])
+              await Util.delay_msec_async(delay)
+              request_image(item.url, item.ctx)
+            elif result[0] != OK or result[1] != 200:
+              push_error("failed to fetch image ", result[0], " ", result[1], " ", item.url)
             else:
               data = result[3]
               _write_url(item.url, data)
@@ -85,6 +98,7 @@ func _texture_load_item():
       elif fmt == "WebP":
         image.load_webp_from_buffer(data)
       else:
+        print("Unknown image type: ", item.url)
         return
 
       if image.get_width() == 0:

--- a/scenes/util/RequestSync.gd
+++ b/scenes/util/RequestSync.gd
@@ -3,16 +3,21 @@ extends Node
 var port = 443
 var protocol = "https://"
 var DELAY_MS = 10
-var USER_AGENT = "https://github.com/m4ym4y/wikipedia-museum"
+var GODOT_VERSION_INFO = Engine.get_version_info()
+var GODOT_VERSION_STRING = "%d.%d.%d" % [GODOT_VERSION_INFO.major, GODOT_VERSION_INFO.minor, GODOT_VERSION_INFO.patch]
+var USER_AGENT = "MoAT/1.1.0 (https://github.com/m4ym4y/museum-of-all-things; contact@may.as) Godot/" + GODOT_VERSION_STRING
 var COMMON_HEADERS = [
   "accept: application/json; charset=utf-8",
-  "user-agent: " + USER_AGENT
 ]
 
 # TODO: a version where we reuse the http client
 func request(url, headers=COMMON_HEADERS, verbose=true):
   if OS.is_debug_build() and verbose:
     print("fetching url ", url)
+
+  # We always add the user agent.
+  var complete_headers = headers.duplicate()
+  complete_headers.push_back("user-agent: " + USER_AGENT)
 
   var http_client = HTTPClient.new()
   var host_idx = url.find("/", len(protocol)) # first slash after protocol
@@ -33,7 +38,7 @@ func request(url, headers=COMMON_HEADERS, verbose=true):
   if http_client.get_status() != HTTPClient.STATUS_CONNECTED:
     return [FAILED, 0, null, null]
 
-  http_client.request(HTTPClient.METHOD_GET, path, headers)
+  http_client.request(HTTPClient.METHOD_GET, path, complete_headers)
 
   while http_client.get_status() == HTTPClient.STATUS_REQUESTING:
     http_client.poll()
@@ -61,9 +66,14 @@ func request_async(url, headers=COMMON_HEADERS, verbose=true):
   if OS.is_debug_build() and verbose:
     print("fetching url ", url)
 
+  var complete_headers
   if Util.is_web():
     # Headers don't always work from the web, let's just not send any.
-    headers = []
+    complete_headers = []
+  else:
+    # We always add the user agent.
+    complete_headers = headers.duplicate()
+    complete_headers.push_back("user-agent: " + USER_AGENT)
 
   var resp = ResponseAsync.new()
 
@@ -73,7 +83,7 @@ func request_async(url, headers=COMMON_HEADERS, verbose=true):
 
   var do_request = func(parent):
     parent.add_child(req)
-    req.request(url, headers)
+    req.request(url, complete_headers)
 
   do_request.call_deferred(self)
 

--- a/scenes/util/Util.gd
+++ b/scenes/util/Util.gd
@@ -67,11 +67,21 @@ func get_max_slots_per_exhibit() -> int:
   # @todo Should this be a setting?
   return 200 if (is_mobile() or is_web()) else 2500
 
+# This is a "true delay" that will only take effect on a worker thread; it will be ignored on the main thread.
 func delay_msec(msecs):
-  # Will only delay if we're not on the main thread.
   if OS.get_thread_caller_id() == OS.get_main_thread_id():
     return
   OS.delay_msec(msecs)
+
+# This is an "async delay" (needs `await`) when used on the main thread, or a "true delay" on a worker thread.
+func delay_msec_async(msecs):
+  # If on the main thread, this will `await` - otherwise, a normal delay
+  if OS.get_thread_caller_id() == OS.get_main_thread_id():
+    var main_loop = Engine.get_main_loop()
+    if main_loop is SceneTree:
+      await main_loop.create_timer(msecs / 1000.0).timeout
+  else:
+    OS.delay_msec(msecs)
 
 func normalize_url(url):
   if url.begins_with('//'):


### PR DESCRIPTION
Over the last couple months, I've noticed that the number of failed images has increased dramatically!

I finally got around to investigating, and it looks like it's from getting rate limited (HTTP 429 errors):

See: https://www.mediawiki.org/wiki/Wikimedia_APIs/Rate_limits

_(It says "API rate limits are being deployed in 2026" so this seems to be fairly new)_

This PR makes a couple of changes:

- **Images are only cached if the HTTP code is 200.** Previously, it would cache anything where the request returned Godot's `OK` error code, but that is returned any time we get the response successfully (including 3xx, 4xx and 5xx responses). This would lead to only the first couple images loading in exhibits you've already visited, even on subsequent visits, because the rate limited failure was cached.
- **Images that get HTTP code 429 are requeued after `Retry-After` seconds.** Retrying after this amount of time comes straight from the docs linked above.
- **Update the `User-Agent` to match the [User-Agent Policy](https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy) and be sure to always pass it.** Previously, we just used the GitHub link, and only passed it on some requests, but not the image downloads which is what is getting rate limited.
- **We now log something when we get an image with an "Unknown" format.** This was the first clue in tracking this issue down: the 429 responses didn't contain valid images. I think this is good information to log in general, and may help us find other issues in the future.

~~The result after the PR still isn't ideal: it can take a very, _very_ long time for all the images to load in a big exhibit. I've been testing primarily with the "Frida Kahlo" exhibit, and I left it running for 30 minutes, and there were still some images that hadn't loaded. :-/ But I'm not sure what else we can do with purely technical changes.~~

~~I tried setting the "User-Agent" to match Chrome (which is against the User-Agent Policy, although, browsers supposedly get a higher limit) but that didn't seem to make any difference :-/~~

~~The only full solution may be social: negotiating something with the Wikipedia~~

**UPDATE:** The addition of the `User-Agent` changes (point nr 3 above) have improved this considerably!

However, this PR definitely makes things better! I went from only like ~6 images loading in the Frida Kahlo exhibit to like ~90+ loading after enough waiting