### PR TITLE
Fix "clicking" on terminal in VR when using hand tracking

### DIFF
--- a/scenes/XRRoot.gd
+++ b/scenes/XRRoot.gd
@@ -234,7 +234,7 @@ func _on_xr_controller_3d_left_input_float_changed(name: String, value: float) -
           if not _is_openxr_hand_tracking_aim_enabled():
             _toggle_menu()
         else:
-          if menu_active:
+          if menu_active or left_controller.get_node("FunctionPointer/Laser").visible:
             xr_tracker.set_input(PINCH_POINTER_ACTION, true)
           else:
             if movement_style == "teleportation":


### PR DESCRIPTION
While testing before making an updated build for the Meta Quest store, I discovered that "clicking" on the terminal when using hand-tracking wasn't working. This PR fixes it!