### PR TITLE
Improve scaling options and add anti-aliasing

### DIFF
--- a/scenes/menu/GraphicsSettings.gd
+++ b/scenes/menu/GraphicsSettings.gd
@@ -16,10 +16,12 @@ func _ready() -> void:
     _vbox.get_node("DisplayOptions").visible = false
     _vbox.get_node("PostProcessingOptions").visible = false
 
-  if _vbox.get_node("DisplayOptions/ScaleMode").selected == 0:
-    get_tree().set_group("fsr_options", "visible", false)
-  else:
-    _vbox.get_node("DisplayOptions/RenderScale").hide()
+  var scale_mode_selected = _vbox.get_node("DisplayOptions/ScaleMode").selected
+  get_tree().set_group("fsr_options", "visible", scale_mode_selected != 0)
+  get_tree().set_group("bilinear_options", "visible", scale_mode_selected == 0)
+
+  _vbox.get_node("DisplayOptions/FSR1Quality").visible = scale_mode_selected == 1
+  _vbox.get_node("DisplayOptions/FSR2Quality").visible = scale_mode_selected == 2
 
 func ui_cancel_pressed():
   if visible:
@@ -42,7 +44,7 @@ func _load_settings():
   _vbox.get_node("DisplayOptions/Fullscreen").button_pressed = GraphicsManager.fullscreen
   _vbox.get_node("DisplayOptions/RenderScale").value = GraphicsManager.render_scale
   _vbox.get_node("DisplayOptions/ScaleMode").selected = GraphicsManager.scale_mode
-  _vbox.get_node("DisplayOptions/FSRQuality").selected = GraphicsManager.fsr_quality
+  _vbox.get_node("DisplayOptions/FSR1Quality").selected = GraphicsManager.fsr_quality
   _vbox.get_node("DisplayOptions/SharpnessScale").value = GraphicsManager.fsr_sharpness
   _vbox.get_node("ReflectionOptions/ReflectionQuality").value = e.ssr_max_steps
   _vbox.get_node("ReflectionOptions/EnableReflections").button_pressed = e.ssr_enabled
@@ -53,11 +55,19 @@ func _load_settings():
   var idx = post_processing_options.find(post_processing)
   _vbox.get_node("PostProcessingOptions/PostProcessingEffect").select(idx if idx >= 0 else 0)
 
-  _update_scaling()
+  match GraphicsManager.fsr_quality:
+    5:
+      _vbox.get_node("DisplayOptions/FSR2Quality").selected = 1
+    var x:
+      _vbox.get_node("DisplayOptions/FSR2Quality").selected = x + 2
+
+  _update_options()
 
 func _on_restore_pressed():
   GraphicsManager.restore_default_settings()
   _load_settings()
+
+  _update_options()
 
 func _on_resume_pressed():
   GraphicsManager.save_settings()
@@ -94,48 +104,51 @@ func _on_fullscreen_toggled(toggled_on: bool):
   GraphicsManager.set_fullscreen(toggled_on)
   _vbox.get_node("DisplayOptions/Fullscreen").set_pressed_no_signal(toggled_on)
 
-func _update_scaling():
+func _update_options():
+  GraphicsManager.set_anti_aliasing(_vbox.get_node("DisplayOptions/AAMode").selected)
+
   var scale_mode = _vbox.get_node("DisplayOptions/ScaleMode").selected
   GraphicsManager.set_scale_mode(scale_mode)
 
-  # Show render scale if bilinear, FSR options otherwise
-  _vbox.get_node("DisplayOptions/RenderScale").visible = (scale_mode == 0)
-  get_tree().set_group("fsr_options", "visible", (scale_mode != 0))
+  match scale_mode:
+    0:
+      GraphicsManager.set_render_scale(_vbox.get_node("DisplayOptions/RenderScale").value)
+    1:
+      var selected = _vbox.get_node("DisplayOptions/FSR1Quality").selected
+      GraphicsManager.set_fsr_quality(_vbox.get_node("DisplayOptions/FSR1Quality").get_item_id(selected))
+    2:
+      var selected = _vbox.get_node("DisplayOptions/FSR2Quality").selected
+      GraphicsManager.set_fsr_quality(_vbox.get_node("DisplayOptions/FSR2Quality").get_item_id(selected))
 
-  if scale_mode == 0:  # Bilinear
-    GraphicsManager.set_render_scale(_vbox.get_node("DisplayOptions/RenderScale").value)
-    return
+func _on_scale_mode_value_changed(value: int):
+  get_tree().set_group("fsr_options", "visible", value != 0)
+  get_tree().set_group("bilinear_options", "visible", value == 0)
+  _vbox.get_node("DisplayOptions/FSR1Quality").visible = value == 1
+  _vbox.get_node("DisplayOptions/FSR2Quality").visible = value == 2
 
-  # FSR
-  var fsr_quality = _vbox.get_node("DisplayOptions/FSRQuality")
-  if scale_mode == 1:  # FSR 1 has no "ultra performance"
-    fsr_quality.set_item_disabled(0, false)
-    fsr_quality.set_item_disabled(4, true)
-  if scale_mode == 2:  # FSR 2 has no "ultra quality"
-    fsr_quality.set_item_disabled(0, true)
-    fsr_quality.set_item_disabled(4, false)
+  # AMD says that you have to use AA for FSR1
+  _vbox.get_node("DisplayOptions/AAMode").set_item_disabled(0, value == 1)
+  # FSR2 is not compatible with TAA
+  _vbox.get_node("DisplayOptions/AAMode").set_item_disabled(6, value == 2)
 
-  GraphicsManager.set_fsr_quality(fsr_quality.selected)
+  if value == 1:
+    _vbox.get_node("DisplayOptions/AAMode").select(6) # Default to TAA for FSR1
+    _vbox.get_node("DisplayOptions/FSR1Quality").select(0) # Ultra quality
+  elif value == 2:
+    _vbox.get_node("DisplayOptions/AAMode").select(0) # Default to no AA for FSR2
+    _vbox.get_node("DisplayOptions/FSR2Quality").select(3) # Quality
 
-  var scale = get_viewport().scaling_3d_scale
-  _vbox.get_node("DisplayOptions/RenderScale").value = scale
-  _vbox.get_node("DisplayOptions/RenderScaleValue").text = "%.0f %%\n" % (scale * 100)
+  _update_options()
 
 func _on_render_scale_value_changed(value: float):
   _vbox.get_node("DisplayOptions/RenderScaleValue").text = "%d %%\n" % (value * 100)
-  _update_scaling()
+  _update_options()
 
-func _on_scale_mode_value_changed(value: int):
-  match value:
-    1:
-      _vbox.get_node("DisplayOptions/FSRQuality").select(0)
-    2:
-      _vbox.get_node("DisplayOptions/FSRQuality").select(1)
+func _on_aa_mode_item_selected(_index: int) -> void:
+    _update_options()
 
-  _update_scaling()
-
-func _on_fsr_quality_item_selected(index: int) -> void:
-  _update_scaling()
+func _on_fsr_quality_item_selected(_index: int) -> void:
+  _update_options()
 
 func _on_sharpness_scale_value_changed(value: float) -> void:
   GraphicsManager.set_fsr_sharpness(value)

--- a/scenes/menu/GraphicsSettings.tscn
+++ b/scenes/menu/GraphicsSettings.tscn
@@ -56,14 +56,16 @@ popup/item_2/text = "AMD FSR 2"
 popup/item_2/id = 2
 
 [node name="Label2" type="Label" parent="DisplayOptions" groups=["fsr_options"]]
+visible = false
 layout_mode = 2
 text = "FSR quality mode"
 
-[node name="FSRQuality" type="OptionButton" parent="DisplayOptions" groups=["fsr_options"]]
+[node name="FSR1Quality" type="OptionButton" parent="DisplayOptions" groups=["fsr_options"]]
+visible = false
 layout_mode = 2
 selected = 0
-item_count = 5
-popup/item_0/text = "Ultra quality"
+item_count = 4
+popup/item_0/text = "Ultra Quality"
 popup/item_0/id = 0
 popup/item_1/text = "Quality"
 popup/item_1/id = 1
@@ -71,41 +73,87 @@ popup/item_2/text = "Balanced"
 popup/item_2/id = 2
 popup/item_3/text = "Performance"
 popup/item_3/id = 3
-popup/item_4/text = "Ultra performance"
-popup/item_4/id = 4
+
+[node name="FSR2Quality" type="OptionButton" parent="DisplayOptions" groups=["fsr_options"]]
+visible = false
+layout_mode = 2
+selected = 1
+item_count = 7
+popup/item_0/text = "Anti-aliasing only"
+popup/item_0/id = 0
+popup/item_0/separator = true
+popup/item_1/text = "Native"
+popup/item_1/id = 5
+popup/item_2/text = "With scaling"
+popup/item_2/id = 0
+popup/item_2/separator = true
+popup/item_3/text = "Quality"
+popup/item_3/id = 1
+popup/item_4/text = "Balanced"
+popup/item_4/id = 2
+popup/item_5/text = "Performance"
+popup/item_5/id = 3
+popup/item_6/text = "High Performance"
+popup/item_6/id = 4
 
 [node name="Label3" type="Label" parent="DisplayOptions" groups=["fsr_options"]]
+visible = false
 layout_mode = 2
 text = "FSR Sharpness"
 
 [node name="SharpnessScale" type="HSlider" parent="DisplayOptions" groups=["fsr_options"]]
+visible = false
 layout_mode = 2
 max_value = 2.0
 step = 0.05
 value = 0.2
 
 [node name="SharpnessScaleValue" type="Label" parent="DisplayOptions" groups=["fsr_options"]]
+visible = false
 layout_mode = 2
 text = "0.2
 "
 horizontal_alignment = 1
 
-[node name="Label4" type="Label" parent="DisplayOptions"]
+[node name="Label4" type="Label" parent="DisplayOptions" groups=["bilinear_options"]]
 layout_mode = 2
 text = "Render Scale"
 
-[node name="RenderScale" type="HSlider" parent="DisplayOptions"]
+[node name="RenderScale" type="HSlider" parent="DisplayOptions" groups=["bilinear_options"]]
 layout_mode = 2
 min_value = 0.1
 max_value = 1.0
 step = 0.05
 value = 1.0
 
-[node name="RenderScaleValue" type="Label" parent="DisplayOptions"]
+[node name="RenderScaleValue" type="Label" parent="DisplayOptions" groups=["bilinear_options"]]
 layout_mode = 2
 text = "100 %
 "
 horizontal_alignment = 1
+
+[node name="Label5" type="Label" parent="DisplayOptions" groups=["aa_options"]]
+layout_mode = 2
+text = "Anti-aliasing"
+
+[node name="AAMode" type="OptionButton" parent="DisplayOptions" groups=["aa_options"]]
+layout_mode = 2
+selected = 0
+item_count = 7
+popup/item_0/text = "None"
+popup/item_0/id = 0
+popup/item_1/text = "FXAA"
+popup/item_1/id = 1
+popup/item_2/text = "SMAA"
+popup/item_2/id = 2
+popup/item_3/text = "MSAA 2×"
+popup/item_3/id = 3
+popup/item_4/text = "MSAA 4×"
+popup/item_4/id = 4
+popup/item_5/text = "MSAA 8×"
+popup/item_5/id = 5
+popup/item_6/text = "TAA"
+popup/item_6/id = 6
 
 [node name="Fullscreen" type="CheckBox" parent="DisplayOptions"]
 layout_mode = 2
@@ -266,9 +314,11 @@ popup/item_1/id = 1
 [connection signal="pressed" from="MainOptions/Back" to="." method="_on_resume_pressed"]
 [connection signal="pressed" from="MainOptions/Restore" to="." method="_on_restore_pressed"]
 [connection signal="item_selected" from="DisplayOptions/ScaleMode" to="." method="_on_scale_mode_value_changed"]
-[connection signal="item_selected" from="DisplayOptions/FSRQuality" to="." method="_on_fsr_quality_item_selected"]
+[connection signal="item_selected" from="DisplayOptions/FSR1Quality" to="." method="_on_fsr_quality_item_selected"]
+[connection signal="item_selected" from="DisplayOptions/FSR2Quality" to="." method="_on_fsr_quality_item_selected"]
 [connection signal="value_changed" from="DisplayOptions/SharpnessScale" to="." method="_on_sharpness_scale_value_changed"]
 [connection signal="value_changed" from="DisplayOptions/RenderScale" to="." method="_on_render_scale_value_changed"]
+[connection signal="item_selected" from="DisplayOptions/AAMode" to="." method="_on_aa_mode_item_selected"]
 [connection signal="toggled" from="DisplayOptions/Fullscreen" to="." method="_on_fullscreen_toggled"]
 [connection signal="value_changed" from="ReflectionOptions/ReflectionQuality" to="." method="_on_reflection_quality_value_changed"]
 [connection signal="toggled" from="ReflectionOptions/EnableReflections" to="." method="_on_enable_reflections_toggled"]

--- a/scenes/util/GraphicsManager.gd
+++ b/scenes/util/GraphicsManager.gd
@@ -14,6 +14,7 @@ var fps_limit = 60
 var _default_settings_obj
 var fullscreen = false
 var render_scale = 1.0
+var anti_aliasing = 0
 var scale_mode = 0
 var fsr_quality = 5
 var fsr_sharpness = 0.2
@@ -46,33 +47,45 @@ func set_fullscreen(_fullscreen: bool):
   else:
     DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
 
+func set_anti_aliasing(mode: int):
+  anti_aliasing = mode
+
+  if mode < 3:
+    get_viewport().screen_space_aa = mode as Viewport.ScreenSpaceAA
+    get_viewport().msaa_3d = Viewport.MSAA_DISABLED
+    get_viewport().use_taa = false
+  elif mode < 6:
+    get_viewport().screen_space_aa = Viewport.SCREEN_SPACE_AA_DISABLED
+    get_viewport().msaa_3d = (mode - 2) as Viewport.MSAA
+    get_viewport().use_taa = false
+  else:
+      get_viewport().screen_space_aa = Viewport.SCREEN_SPACE_AA_DISABLED
+      get_viewport().msaa_3d = Viewport.MSAA_DISABLED
+      get_viewport().use_taa = true
+
 func set_render_scale(scale: float):
-  render_scale = scale
   get_viewport().scaling_3d_scale = scale
 
 func set_scale_mode(mode: int):
   scale_mode = mode
   get_viewport().scaling_3d_mode = mode as Viewport.Scaling3DMode
 
-  if mode < 2:
-    get_viewport().msaa_3d = Viewport.MSAA_2X
-  else:
-    get_viewport().msaa_3d = Viewport.MSAA_DISABLED
-
 func set_fsr_quality(quality: int):
   fsr_quality = quality
 
   match quality:
     0:
-      get_viewport().scaling_3d_scale = 1.0 / 1.3
+      set_render_scale(1.0 / 1.3)
     1:
-      get_viewport().scaling_3d_scale = 1.0 / 1.5
+      set_render_scale(1.0 / 1.5)
     2:
-      get_viewport().scaling_3d_scale = 1.0 / 1.7
+      set_render_scale(1.0 / 1.7)
     3:
-      get_viewport().scaling_3d_scale = 1.0 / 2.0
+      set_render_scale(1.0 / 2.0)
     4:
-      get_viewport().scaling_3d_scale = 1.0 / 3.0
+      set_render_scale(1.0 / 3.0)
+    5:
+      set_render_scale(1.0)
 
 func set_fsr_sharpness(sharpness: float):
     get_viewport().fsr_sharpness = sharpness
@@ -121,6 +134,7 @@ func _apply_settings(s, default={}):
     set_fullscreen(s["fullscreen"] if s.has("fullscreen") else default["fullscreen"])
     set_fsr_sharpness(s["fsr_sharpness"] if s.has("fsr_sharpness") else default["fsr_sharpness"])
     set_post_processing(s["post_processing"] if s.has("post_processing") else default["post_processing"])
+    set_anti_aliasing(s["anti_aliasing"] if s.has("anti_aliasing") else default["anti_aliasing"])
 
     var mode = s["scale_mode"] if s.has("scale_mode") else default["scale_mode"]
     set_scale_mode(mode)
@@ -142,6 +156,7 @@ func _create_settings_obj():
     "fps_limit": fps_limit,
     "limit_fps": limit_fps,
     "fullscreen": fullscreen,
+    "anti_aliasing": anti_aliasing,
     "render_scale": render_scale,
     "scale_mode": scale_mode,
     "fsr_quality": fsr_quality,


### PR DESCRIPTION
When I added the scaling options, I remember having a bit of trouble with getting the UI to be consistent. Hopefully this is fixed now.

I've also added an anti-aliasing option, although there are problems with particular combinations of FSR and anti-aliasing which complicate matters. [AMD request that the best anti-aliasing method be used when selecting FSR1](https://gpuopen.com/fidelityfx-naming-guidelines/#fsr). FSR2 already includes temporal anti-aliasing, and Godot in fact prohibits this combination, and I've just seen that SMAA [doesn't work well either](https://github.com/godotengine/godot/issues/111650). I'm tending towards disabling AA completely and hiding the UI if FSR2 is selected.

In any case, I'm probably overthinking things as usual!