### PR TITLE
Add sliding divider when new rooms are added to exhibits

### DIFF
--- a/scenes/TiledExhibitGenerator.gd
+++ b/scenes/TiledExhibitGenerator.gd
@@ -7,6 +7,7 @@ signal exit_added(exit)
 @onready var small_planter_scene = preload("res://scenes/items/SmallPlanter.tscn")
 @onready var hall = preload("res://scenes/Hall.tscn")
 @onready var grid_wrapper = preload("res://scenes/util/GridWrapper.tscn")
+@onready var sliding_hall_divider = preload("res://scenes/items/SlidingHallDivider.tscn")
 
 @onready var _rng
 @onready var title
@@ -199,8 +200,15 @@ func _create_next_room_candidate(last_room):
 
   _grid.reserve_zone(hall_bounds)
   _grid.reserve_zone(room_bounds)
+
   room_obj.bounds = room_bounds
   room_obj.hall = hall_bounds
+  room_obj.last_room = {
+    "center": last_room.center,
+    "width": last_room.width,
+    "length": last_room.length,
+  }
+
   _next_room_candidates.append(room_obj)
 
 func _add_to_room_list(c, w, l):
@@ -223,6 +231,32 @@ func add_room():
   var room = _next_room_candidates.pop_at(idx)
 
   _grid.free_reserved_zone(room.center)
+
+  # calculate edge of previous room to place sliding hall divider
+  if "last_room" in room:
+    var room_dir = (room.center - room.last_room.center).normalized()
+    var hall_width = 1 + (room.hall[1].x - room.hall[0].x if room_dir.z != 0 else room.hall[1].z - room.hall[0].z)
+    var divider = sliding_hall_divider.instantiate()
+    var last_room_bounds = room_to_bounds(room.last_room.center, room.last_room.width, room.last_room.length)
+
+    if room_dir.z != 0:
+      var z_center = last_room_bounds[0].z if room_dir.z < 0 else last_room_bounds[1].z
+      divider.global_position = Util.gridToWorld(0.5 * room_dir + Vector3(
+        (room.hall[1].x + room.hall[0].x) / 2.0,
+        room.center.y,
+        z_center))
+    else:
+      var x_center = last_room_bounds[0].x if room_dir.x < 0 else last_room_bounds[1].x
+      divider.global_position = Util.gridToWorld(0.5 * room_dir + Vector3(
+        x_center,
+        room.center.y,
+        (room.hall[1].z + room.hall[0].z) / 2.0))
+
+    divider.scale.x = hall_width
+    divider.rotation.y = (PI / 2 if room_dir.z == 0 else 0)
+    divider.rotation.y += (PI if room_dir.x > 0 or room_dir.z > 0 else 0)
+    add_child(divider)
+    divider.init()
 
   _add_to_room_list(room.center, room.width, room.length)
   carve_room(room.hall[0], room.hall[1], _y)

--- a/scenes/items/SlidingHallDivider.gd
+++ b/scenes/items/SlidingHallDivider.gd
@@ -1,0 +1,17 @@
+extends Node3D
+
+func init():
+  var slide_tween = create_tween()
+  slide_tween.tween_property(
+    $MeshInstance3D,
+    "position",
+    Vector3(0, 13, 0),
+    1.0)
+
+  $SlideSound.play()
+  slide_tween.set_trans(Tween.TRANS_LINEAR)
+  slide_tween.set_ease(Tween.EASE_IN_OUT)
+  slide_tween.finished.connect(_on_slide_finished)
+
+func _on_slide_finished():
+  queue_free()

--- a/scenes/items/SlidingHallDivider.gd.uid
+++ b/scenes/items/SlidingHallDivider.gd.uid
@@ -1,0 +1,1 @@
+uid://bdaqa76jolixw

--- a/scenes/items/SlidingHallDivider.tscn
+++ b/scenes/items/SlidingHallDivider.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=6 format=3 uid="uid://bqnx68ab5f0ek"]
+
+[ext_resource type="Script" uid="uid://bdaqa76jolixw" path="res://scenes/items/SlidingHallDivider.gd" id="1_a8fus"]
+[ext_resource type="Material" uid="uid://datvvi6j3c0kp" path="res://assets/textures/white.tres" id="1_q84oc"]
+[ext_resource type="AudioStream" uid="uid://c4hu7i85d0ohs" path="res://assets/sound/Environmental Ambience/Doors and Objects/Object Slide 4.ogg" id="3_7dr8n"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_ss8xh"]
+material = ExtResource("1_q84oc")
+size = Vector3(4, 8, 0.1)
+
+[sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_q84oc"]
+points = PackedVector3Array(2, 0.25, 0.05, 2, 0.25, -0.05, -2, 0.25, 0.05, 2, -0.25, 0.05, 2, -0.25, -0.05, -2, 0.25, -0.05, -2, -0.25, 0.05, -2, -0.25, -0.05)
+
+[node name="SlidingHallDivider" type="Node3D"]
+script = ExtResource("1_a8fus")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, -0.05)
+mesh = SubResource("BoxMesh_ss8xh")
+
+[node name="StaticBody3D2" type="StaticBody3D" parent="MeshInstance3D"]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="MeshInstance3D/StaticBody3D2"]
+shape = SubResource("ConvexPolygonShape3D_q84oc")
+
+[node name="SlideSound" type="AudioStreamPlayer3D" parent="."]
+stream = ExtResource("3_7dr8n")
+volume_db = 5.0
+pitch_scale = 0.5
+max_distance = 20.0
+bus = &"Sound"


### PR DESCRIPTION

https://github.com/user-attachments/assets/12e73723-4bb3-462a-a3fe-bfcffd90b529

Adds a sliding divider when new rooms are added to an exhibit. This should help with the 'pop-in' effect when new parts of an exhibit are loaded in.

I'll merge this unless anyone has any thoughts in the next day or so! You can see it's not a complete solve-- there are still elements that pop-out (the plants along the wall just vanish) but I can add more transitions to help sell the physicality of the museum even when the exhibits are changed to load more content :)

The bad framerate is bc i do all my dev on my laptop and it really cannot run and record at the same time lol :p