### PR TITLE
Linux: bump to fdo-sdk 25.08

### DIFF
--- a/as.may.moat.yml
+++ b/as.may.moat.yml
@@ -1,6 +1,6 @@
 id: as.may.moat
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 base: org.godotengine.godot.BaseApp
 base-version: '4.5'
 sdk: org.freedesktop.Sdk


### PR DESCRIPTION
Matching the base app

# MoAT Contributing Checklist

- [x] Have you tested your code locally?
- [x] **AI output is not allowed in the Museum of All Things codebase -- Do you attest that your pull request is free of generative AI usage?**

## Describe your Changes

Just a one-line change to match the Freedesktop platform version for the Godot 4.5 base app: https://github.com/flathub/org.godotengine.godot.BaseApp/blob/e1d3bdfa07877b63d3bd7716dee652a32b3c6b0b/org.godotengine.godot.BaseApp.yaml#L4