### PR TITLE
Fix OOM on standalone XR by more aggresively erasing exhibits

### DIFF
--- a/scenes/Main.gd
+++ b/scenes/Main.gd
@@ -23,6 +23,10 @@ func _ready():
 
   _recreate_player()
 
+  # Mobile and web should keep fewer exhibits loaded to prevent running out of memory.
+  if Util.is_mobile() or Util.is_web():
+    $Museum.max_exhibits_loaded = 2
+
   if Util.is_xr():
     _start_game()
   else:

--- a/scenes/Museum.gd
+++ b/scenes/Museum.gd
@@ -30,9 +30,6 @@ var _grid
 var _player
 var _custom_door
 
-func _init():
-  RenderingServer.set_debug_generate_wireframes(true)
-
 func init(player):
   _player = player
   _set_up_lobby($Lobby)
@@ -154,11 +151,16 @@ func _teleport(from_hall, to_hall, entry_to_exit=false):
   _prepare_halls_for_teleport(from_hall, to_hall, entry_to_exit)
 
 func _prepare_halls_for_teleport(from_hall, to_hall, entry_to_exit=false):
-  if not is_instance_valid(from_hall) or not is_instance_valid(to_hall):
+  # If the to_hall doesn't exist yet, we teleport right away without animating,
+  # so the player can't get stuck between exhibits.
+  if not is_instance_valid(to_hall):
+    _teleport_player(from_hall, to_hall, entry_to_exit)
     return
 
-  from_hall.entry_door.set_open(false)
-  from_hall.exit_door.set_open(false)
+  if is_instance_valid(from_hall):
+    from_hall.entry_door.set_open(false)
+    from_hall.exit_door.set_open(false)
+
   to_hall.entry_door.set_open(false, true)
   to_hall.exit_door.set_open(false, true)
 
@@ -172,8 +174,13 @@ func _prepare_halls_for_teleport(from_hall, to_hall, entry_to_exit=false):
   timer.start(HallDoor.animation_duration)
 
 func _toggle_exhibit_visibility(hide_title: String, show_title: String) -> void:
-  var old_exhibit = _exhibits[hide_title]['exhibit']
-  old_exhibit.visible = false
+  # If the new exhibit doesn't exist yet, we leave the old one shown for now.
+  if not _exhibits.has(show_title):
+    return
+
+  if _exhibits.has(hide_title):
+    var old_exhibit = _exhibits[hide_title]['exhibit']
+    old_exhibit.visible = false
 
   var new_exhibit = _exhibits[show_title]['exhibit']
   new_exhibit.visible = true
@@ -218,7 +225,8 @@ func _teleport_player(from_hall, to_hall, entry_to_exit=false):
       _load_exhibit_from_entry(to_hall)
 
 func _on_loader_body_entered(body, hall, backlink=false):
-  if hall.to_title == "" or hall.to_title == _current_room_title:
+  var target = hall.from_title if backlink else hall.to_title
+  if target == "" or target == _current_room_title:
     return
 
   if body.is_in_group("Player"):
@@ -298,6 +306,8 @@ func _init_item(exhibit, item, data):
     item.init(data)
 
 func _link_halls(entry, exit):
+  _backlink_map[exit.to_title] = { "title": exit.from_title, "hall_type": exit.hall_type }
+
   if entry.linked_hall == exit and exit.linked_hall == entry:
     return
 
@@ -305,7 +315,6 @@ func _link_halls(entry, exit):
     Util.clear_listeners(hall, "on_player_toward_exit")
     Util.clear_listeners(hall, "on_player_toward_entry")
 
-  _backlink_map[exit.to_title] = exit.from_title
   exit.on_player_toward_exit.connect(_teleport.bind(exit, entry))
   entry.on_player_toward_entry.connect(_teleport.bind(entry, exit, true))
   exit.linked_hall = entry
@@ -336,6 +345,7 @@ func _erase_exhibit(key):
   _exhibits[key].exhibit.queue_free()
   _release_exhibit_height(_exhibits[key].height)
   _global_item_queue_map.erase(key)
+  WorkQueue.clear_exhibit(key)
   _exhibits.erase(key)
   var i = _exhibit_hist.find(key)
   if i >= 0:
@@ -354,8 +364,11 @@ func _on_fetch_complete(_titles, context):
     return
 
   var prev_title
+  var entry_hall_type = hall.hall_type
   if backlink:
-    prev_title = _backlink_map[context.title]
+    var link = _backlink_map[context.title]
+    prev_title = link.title
+    entry_hall_type = link.hall_type
   else:
     prev_title = hall.from_title
 
@@ -364,8 +377,18 @@ func _on_fetch_complete(_titles, context):
   var data
   while not data:
     data = await ItemProcessor.items_complete
+    if not is_instance_valid(hall):
+      return
     if data.title != context.title:
       data = null
+
+  # Don't re-generate the exhibit again.
+  if _exhibits.has(context.title):
+    if backlink:
+      _link_backlink_to_exit(_exhibits[context.title].exhibit, hall)
+    else:
+      _load_exhibit_from_exit(hall)
+    return
 
   var doors = data.doors
   var items = data.items
@@ -387,7 +410,7 @@ func _on_fetch_complete(_titles, context):
     "title": context.title,
     "prev_title": prev_title,
     "no_props": len(items) < 10,
-    "hall_type": hall.hall_type,
+    "hall_type": entry_hall_type,
     "exit_limit": len(doors),
   })
 
@@ -399,7 +422,7 @@ func _on_fetch_complete(_titles, context):
         var key = _exhibit_hist[e]
         if _exhibits.has(key):
           var old_exhibit = _exhibits[key]
-          if abs(4 * old_exhibit.height - _player.position.y) < 20:
+          if key == _current_room_title:
             continue
           if old_exhibit.exhibit.title == new_exhibit.title:
             continue
@@ -427,6 +450,7 @@ func _on_fetch_complete(_titles, context):
   _queue_item(context.title, item_queue)
 
   if backlink:
+    new_exhibit.entry.exit_door.set_open(true, true)
     new_exhibit.entry.loader.body_entered.connect(_on_loader_body_entered.bind(new_exhibit.entry, true))
   else:
     _link_halls(new_exhibit.entry, hall)
@@ -499,6 +523,8 @@ func _queue_item_front(title, item):
   _queue_item(title, item, true)
 
 func _queue_item(title, item, front = false):
+  if not _exhibits.has(title):
+    return
   if not _global_item_queue_map.has(title):
     _global_item_queue_map[title] = []
   if typeof(item) == TYPE_ARRAY:

--- a/scenes/items/ImageItem.gd
+++ b/scenes/items/ImageItem.gd
@@ -89,7 +89,7 @@ func _set_image(data):
   if data.has("src"):
     image_url = Util.normalize_url(data.src)
     DataManager.loaded_image.connect(_on_image_loaded)
-    DataManager.request_image(data.src)
+    DataManager.request_image(data.src, self)
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/scenes/items/LobbyInfo.gd
+++ b/scenes/items/LobbyInfo.gd
@@ -11,6 +11,7 @@ func _ready() -> void:
     
 func _generate_mipmaps(_lang: String = "") -> void:
   $SubViewport.render_target_update_mode = SubViewport.UPDATE_ONCE
-  MipmapThread.get_viewport_texture_with_mipmaps($SubViewport, func(texture):
-    $Sprite3D.texture = texture
-  )
+  MipmapThread.get_viewport_texture_with_mipmaps($SubViewport, _on_texture_ready)
+
+func _on_texture_ready(texture) -> void:
+  $Sprite3D.texture = texture

--- a/scenes/items/RichTextItem.gd
+++ b/scenes/items/RichTextItem.gd
@@ -12,10 +12,11 @@ func init(text):
   t = Util.replace_unclosed_bbcodes(t)
   label.text = t
   call_deferred("_center_vertically", label)
-  MipmapThread.get_viewport_texture_with_mipmaps.call_deferred($SubViewport, func(texture):
-    $Sprite3D.texture = texture
-    $SubViewport.queue_free()
-  )
+  MipmapThread.get_viewport_texture_with_mipmaps.call_deferred($SubViewport, _on_texture_ready)
+
+func _on_texture_ready(texture):
+  $Sprite3D.texture = texture
+  $SubViewport.queue_free()
 
 func _center_vertically(label):
   # Ensure the SubViewport is sized

--- a/scenes/util/DataManager.gd
+++ b/scenes/util/DataManager.gd
@@ -8,9 +8,12 @@ signal loaded_image(url: String, image: Image)
 
 var TEXTURE_QUEUE = "Textures"
 var TEXTURE_FRAME_PACING = 6
+var MAX_RETRY_DELAY_MS = 60000
 var _fs_lock = Mutex.new()
-var _texture_load_thread_pool_size = 5
+var _texture_load_thread_pool_size = 3
 var _texture_load_thread_pool = []
+var _rate_limit_lock = Mutex.new()
+var _rate_limited_until = 0
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -54,6 +57,11 @@ func _texture_load_item():
 
         if data:
           _load_image(item.url, data, item.ctx)
+          return
+
+        var wait = _get_rate_limit_remaining()
+        if wait > 0:
+          _retry_request_image_later.call_deferred(item.url, item.ctx, wait)
         else:
           var request_url = item.url
           request_url += ('&' if '?' in request_url else '?') + "origin=*"
@@ -69,9 +77,10 @@ func _texture_load_item():
                   if delay_seconds > 0:
                     delay = delay_seconds * 1000
                   break
+              delay = mini(delay, MAX_RETRY_DELAY_MS)
               push_warning("rate limited, requeuing image in %dms: %s" % [delay, item.url])
-              await Util.delay_msec_async(delay)
-              request_image(item.url, item.ctx)
+              _set_rate_limited(delay)
+              _retry_request_image_later.call_deferred(item.url, item.ctx, delay)
             elif result[0] != OK or result[1] != 200:
               push_error("failed to fetch image ", result[0], " ", result[1], " ", item.url)
             else:
@@ -210,6 +219,31 @@ func _emit_image(url, texture, ctx):
   if texture == null:
     return
   call_deferred("emit_signal", "loaded_image", url, texture, ctx)
+
+func _get_rate_limit_remaining() -> int:
+  _rate_limit_lock.lock()
+  var remaining = _rate_limited_until - Time.get_ticks_msec()
+  _rate_limit_lock.unlock()
+  return maxi(remaining, 0)
+
+func _set_rate_limited(delay_msec: int) -> void:
+  _rate_limit_lock.lock()
+  _rate_limited_until = maxi(_rate_limited_until, Time.get_ticks_msec() + delay_msec)
+  _rate_limit_lock.unlock()
+
+func _is_ctx_alive(ctx) -> bool:
+  if typeof(ctx) != TYPE_OBJECT:
+    # A null or non-object ctx means nothing claimed ownership of the request.
+    return true
+  return is_instance_valid(ctx)
+
+func _retry_request_image_later(url, ctx, delay_msec: int) -> void:
+  if not _is_ctx_alive(ctx):
+    return
+  await get_tree().create_timer(delay_msec / 1000.0).timeout
+  if not _is_ctx_alive(ctx):
+    return
+  request_image(url, ctx)
 
 func request_image(url, ctx=null):
   WorkQueue.add_item(TEXTURE_QUEUE, {

--- a/scenes/util/GraphicsManager.gd
+++ b/scenes/util/GraphicsManager.gd
@@ -224,6 +224,8 @@ func _toggle_managed_light(light, enable) -> void:
 
   tween.tween_property(light, "light_energy", light_energy if enable else 0.0, MANAGED_LIGHTS_FREQUENCY * 0.5)
   tween.tween_callback(func ():
+    if not is_instance_valid(light):
+      return
     light.visible = enable
     light.light_energy = light_energy
   )

--- a/scenes/util/MipmapThread.gd
+++ b/scenes/util/MipmapThread.gd
@@ -30,10 +30,15 @@ func _mipmap_process_item():
   if not item:
     return
 
+  if not item.callback.is_valid():
+    return
+
   match item.type:
     "get_texture_data":
       # This item only happens on the compatibility renderer.
       var image = item.texture.get_image()
+      if not image:
+        return
       _generate_mipmaps(image, item.callback)
 
     "create_image":
@@ -57,11 +62,15 @@ func _get_texture_data_rd(texture: Texture2D, callback: Callable):
   var format = RenderingServer.texture_get_format(rid)
   var rd_rid = RenderingServer.texture_get_rd_texture(rid)
   RenderingServer.get_rendering_device().texture_get_data_async(rd_rid, 0, func(array) -> void:
+    if not callback.is_valid():
+      return
     _create_image(width, height, format, array, callback)
   )
 
 func get_viewport_texture_with_mipmaps(subviewport: SubViewport, callback: Callable):
   await RenderingServer.frame_post_draw
+  if not is_instance_valid(subviewport) or not callback.is_valid():
+    return
   if Util.is_compatibility_renderer():
     WorkQueue.add_item(MIPMAP_QUEUE, {
       "type": "get_texture_data",

--- a/scenes/util/ThreadSafeWorkQueue.gd
+++ b/scenes/util/ThreadSafeWorkQueue.gd
@@ -36,6 +36,16 @@ func setup_queue(name, frame_pacing=DEFAULT_FRAME_PACING):
     "frame_pacing": frame_pacing,
   }
 
+func clear_exhibit(title):
+  _global_queue_lock.lock()
+  var queues = _queue_map.values()
+  _global_queue_lock.unlock()
+
+  for queue in queues:
+    queue.lock.lock()
+    queue.exhibit_queues.erase(title)
+    queue.lock.unlock()
+
 func _get_queue(name):
   var res
   _global_queue_lock.lock()


### PR DESCRIPTION
# MoAT Contributing Checklist

- [X] Have you tested your code locally?
- [X] **AI output is not allowed in the Museum of All Things codebase -- Do you attest that your pull request is free of generative AI usage?**

## Describe your Changes Below

While doing some extensive testing on Android XR devices, I started seeing the app getting OOM killed after ~5 minutes.

This PR works around that by more aggressively erasing old exhibits when on mobile or the web (the web is 32-bit, so it inherently has less memory than native desktop apps).

However, after enabling that, I found that backtracking to the erased exhibits didn't always work, so that ended up being the majority of the changes in this PR.

It seems to be working well for me!